### PR TITLE
Adds comments to Move + make masks private + makes toString returns UCI

### DIFF
--- a/src/main/java/com/kelseyde/calvin/board/Move.java
+++ b/src/main/java/com/kelseyde/calvin/board/Move.java
@@ -4,46 +4,77 @@ import java.util.Arrays;
 import java.util.Optional;
 
 /**
- * Represents a single chess move. The move is encoded as a 16-bit integer. Bits 0 - 5 represent the start square,
- * bits 6 - 11 represent the end square, and bits 12 - 15 represent special move flags.
- *
+ * Represents a single chess move.
+ * @param value The move encoded as a 16-bit integer. Bits 0 - 5 represent the start square,
+ * bits 6 - 11 represent the end square, and bits 12 - 15 represent special move flags (one of the constants ending with _FLAG).
  * @see <a href="https://www.chessprogramming.org/Encoding_Moves">Chess Programming Wiki</a>.
  */
 public record Move(short value) {
 
     // Special move flags
+    /** Flag for a standard move (no special flags) */
     public static final short NO_FLAG = 0b0000;
+    /** Flag for a move is en passant pawn capture */
     public static final short EN_PASSANT_FLAG = 0b0001;
+    /** Flag for a castling move */
     public static final short CASTLE_FLAG = 0b0010;
+    /** Flag for a two squares pawn move */
     public static final short PAWN_DOUBLE_MOVE_FLAG = 0b0011;
+    /** Flag for a promotion to a queen */
     public static final short PROMOTE_TO_QUEEN_FLAG = 0b0100;
+    /** Flag for a promotion to a knight */
     public static final short PROMOTE_TO_KNIGHT_FLAG = 0b0101;
+    /** Flag for a promotion to a rook */
     public static final short PROMOTE_TO_ROOK_FLAG = 0b0110;
+    /** Flag for a promotion to a bishop */
     public static final short PROMOTE_TO_BISHOP_FLAG = 0b0111;
 
-    public static final int FROM_MASK = 0b0000000000111111;
-    public static final int TO_MASK = 0b0000111111000000;
+    private static final int FROM_MASK = 0b0000000000111111;
+    private static final int TO_MASK = 0b0000111111000000;
 
+    /** Constructs a new standard move (no castle or pawn double, en passant, or promotion move)
+     * @param from The start square
+     * @param to The end square
+     */
     public Move(int from, int to) {
         this((short) (from | to << 6));
     }
 
+    /**
+     * Constructs a new move from its start, end, and flag
+     * @param from The start square
+     * @param to The end square
+     * @param flag The flag (see constants ending with _FLAG)
+     */
     public Move(int from, int to, int flag) {
         this((short) (from | (to << 6) | (flag << 12)));
     }
 
+    /** Gets the start square of this move
+     * @return an int
+     */
     public int from() {
         return value & FROM_MASK;
     }
 
+    /** Gets the destination square of this move
+     * @return an int
+    */
     public int to() {
         return (value & TO_MASK) >>> 6;
     }
 
+    /** Gets the flag of this move
+     * @return an int
+     */
     public int flag() {
         return value >>> 12;
     }
 
+    /** Gets the promotion piece of this move
+     * @return a Piece or null if this is not a promotion move
+     * @see #isPromotion
+     */
     public Piece promoPiece() {
         return switch (flag()) {
             case PROMOTE_TO_QUEEN_FLAG -> Piece.QUEEN;
@@ -54,24 +85,40 @@ public record Move(short value) {
         };
     }
 
+    /** Checks if this move is a promotion
+     * @return true if this is a promotion move, false otherwise
+     * @see #promoPiece
+     */
     public boolean isPromotion() {
         return flag() >= PROMOTE_TO_QUEEN_FLAG;
     }
 
+    /** Checks if this move is an en passant capture
+     * @return true if this is an en passant move, false otherwise
+     */
     public boolean isEnPassant() {
         return flag() == EN_PASSANT_FLAG;
     }
 
+    /** Checks if this move is a castling move
+     * @return true if this is a castling move, false otherwise
+    */
     public boolean isCastling() {
         return flag() == CASTLE_FLAG;
     }
 
+    /** Checks if this move is a two squares pawn move
+     * @return true if this is a two squares pawn move, false otherwise
+     */
     public boolean isPawnDoubleMove() {
         return flag() == PAWN_DOUBLE_MOVE_FLAG;
     }
 
     /**
-     * Checks if this move matches another move, excluding the special move flag.
+     * Checks if this move matches another move.
+     * <br>A move matches this if their start and end positions are the same and this is not a promotion move, or both moves have the same promotion piece.
+     * @param move The move to compare to
+     * @return true if this move matches the other move, false otherwise
      */
     public boolean matches(Move move) {
         if (move == null) return false;
@@ -83,6 +130,11 @@ public record Move(short value) {
     }
 
     @Override
+    public int hashCode() {
+        return value;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
         if (!(obj instanceof Move move)) return false;
@@ -90,8 +142,13 @@ public record Move(short value) {
     }
 
     /**
-     * Generate a {@link Move} from combined algebraic notation (e.g. "e2e4"), as used in the UCI protocol.
+     * Generates a {@link Move} from combined algebraic notation (e.g. "e2e4"), as used in the UCI protocol.
      * Special case promotion: "a2a1q" - values 'q' | 'b' | 'r' | 'n'
+     * @param uci The move in UCI notation
+     * @return A move.
+     * <br><b>Warning: this method does set the special move flag except in case of promotion.</b>
+     * One way to get a valid move is to find a legal move whose matches method returns true for returned move.
+     * @see #matches(Move)
      */
     public static Move fromUCI(String uci) {
         int from = Square.fromNotation(uci.substring(0, 2));
@@ -108,19 +165,35 @@ public record Move(short value) {
         return new Move(from, to, flag);
     }
 
-    public static Move fromUCI(String uci, int flag) {
+    /**
+     * Generates a {@link Move} from combined algebraic notation (e.g. "e2e4"), as used in the UCI protocol.
+     * Special case promotion: "a2a1q" - values 'q' | 'b' | 'r' | 'n'
+     * @param uci The move in UCI notation
+     * <br><b>Warning: this method ignores the promotion character of the uci notation.</b>
+     * @param flag The special move flag (see constants ending with _FLAG)
+     * @return A move.
+     * <br>Warning: this method does set the special move flag except in case of promotion.
+     */
+       public static Move fromUCI(String uci, int flag) {
         int from = Square.fromNotation(uci.substring(0, 2));
         int to = Square.fromNotation(uci.substring(2, 4));
         return new Move(from, to, flag);
     }
 
+    /**
+     * Generates a UCI representation of a move (e.g. "e2e4").
+     * @param move The move
+     * @return The UCI notation
+     */
     public static String toUCI(Move move) {
         if (move == null) return "-";
-        String notation = Square.toNotation(move.from()) + Square.toNotation(move.to());
-        if (move.promoPiece() != null) {
-            notation += move.promoPiece().code();
-        }
-        return notation;
+        final String notation = Square.toNotation(move.from()) + Square.toNotation(move.to());
+        final Piece promoPiece = move.promoPiece();
+		return promoPiece == null ? notation : notation + promoPiece.code();
     }
 
+	@Override
+	public String toString() {
+		return toUCI(this);
+	}
 }

--- a/src/main/java/com/kelseyde/calvin/board/Move.java
+++ b/src/main/java/com/kelseyde/calvin/board/Move.java
@@ -189,11 +189,11 @@ public record Move(short value) {
         if (move == null) return "-";
         final String notation = Square.toNotation(move.from()) + Square.toNotation(move.to());
         final Piece promoPiece = move.promoPiece();
-		return promoPiece == null ? notation : notation + promoPiece.code();
+        return promoPiece == null ? notation : notation + promoPiece.code();
     }
 
-	@Override
-	public String toString() {
-		return toUCI(this);
-	}
+    @Override
+    public String toString() {
+        return toUCI(this);
+    }
 }


### PR DESCRIPTION
Some improvements to Move
- Adds javadoc comments.
- makes FROM_MASK and TO_MASK private (they seem not to be used outside the Move class)
- Makes the `toString()` method return the UCI notation make debugging easier.

PS: If you plan to add javadoc comments on your side, and If you don't already use it, I recommend [Windsurf editor](https://codeium.com/windsurf): Its auto completion guesses very well the comments you will add 😊
