### PR TITLE
Draw and Square improvements + Add Board.hasBishopPair

### DIFF
--- a/src/main/java/com/kelseyde/calvin/board/Board.java
+++ b/src/main/java/com/kelseyde/calvin/board/Board.java
@@ -591,6 +591,17 @@ public class Board {
                 (getKnights(true) != 0 || getBishops(true) != 0 || getRooks(true) != 0 || getQueens(true) != 0) :
                 (getKnights(false) != 0 || getBishops(false) != 0 || getRooks(false) != 0 || getQueens(false) != 0);
     }
+    
+    /** Tests whether a specified player has a <a href="https://en.wikipedia.org/wiki/Bishop_pair">bishop pair</a> (two bishops on different color squares).
+     * @param white the colour of the player to check
+     * @return true if the board has a bishop pair of the specified player, false otherwise
+     */
+    public boolean hasBishopPair(boolean white) {
+        final long bishops = getBishops(white);
+        final long bishopsOnWhiteSquares = bishops & Square.WHITE;
+        return bishops!=bishopsOnWhiteSquares && bishopsOnWhiteSquares!=0;
+    }
+
 
     public static Board from(String fen) {
         return FEN.toBoard(fen);

--- a/src/main/java/com/kelseyde/calvin/board/Draw.java
+++ b/src/main/java/com/kelseyde/calvin/board/Draw.java
@@ -1,17 +1,42 @@
 package com.kelseyde.calvin.board;
 
-public class Draw {
+import com.kelseyde.calvin.movegen.MoveGenerator;
 
+/** A utility class for checking draw conditions. */
+public final class Draw {
+    private Draw() {
+        super();
+    }
+
+    /** Checks if the board is a draw due to any of the standard chess rules.
+     * @return true if {@link #isThreefoldRepetition} or {@link #isFiftyMoveRule} or {@link #isInsufficientMaterial} or {@link #isStalemate} is true
+     */
+    public static boolean isDraw(Board board, MoveGenerator moveGenerator) {
+        return isThreefoldRepetition(board) || isFiftyMoveRule(board) || isInsufficientMaterial(board) || isStalemate(board, moveGenerator);
+    }
+
+    /** Checks if the board can be considered as a draw by an engine.
+     * <br>WARNING: This method does not check for a <a href="https://en.wikipedia.org/wiki/Stalemate">stalemate</a> and uses {@link #isDoubleRepetition}
+     * and not {@link #isThreefoldRepetition}. So it can't be used to check for a draw in a position in the official game rules.
+     * <br>Usually chess programs would check for a draw using {@link #isDraw(Board board, MoveGenerator)}.
+     * @return true if {@link #isDoubleRepetition} or {@link #isFiftyMoveRule} or {@link #isInsufficientMaterial} is true
+     * @see #isDraw(Board board, MoveGenerator)
+     */
     public static boolean isEffectiveDraw(Board board) {
         return isDoubleRepetition(board) || isFiftyMoveRule(board) || isInsufficientMaterial(board);
     }
 
+    /** Checks if the board is a draw due to <a href="https://en.wikipedia.org/wiki/Threefold_repetition">threefold repetition</a>.
+     * @return true if the board is a draw due to threefold repetition
+     */
     public static boolean isThreefoldRepetition(Board board) {
-
         int repetitionCount = 0;
         long zobrist = board.getState().getKey();
         BoardState[] states = board.getStates();
-        for (int i = board.getPly() - 1; i >= 0; i--) {
+        // No need to check the positions after the last half move clock reset as they are not reproducible
+        int lastReproductiblePly = board.getPly() - board.getState().getHalfMoveClock();
+        for (int i = board.getPly() - 2; i >= lastReproductiblePly; i=i-2) {
+            // decrement i by 2 as we can skip the positions where the player to move is not the current one
             if (states[i].getKey() == zobrist) {
                 repetitionCount += 1;
             }
@@ -19,24 +44,35 @@ public class Draw {
                 return true;
             }
         }
-
         return false;
-
     }
 
+    /** Checks if the current position was already encountered in the board's history.
+     * <br>This is a simplified version of the threefold repetition test often used in engines to speed up the search at the price of some insignificant errors.
+     * <br>Example with fen <i>1R6/8/8/7R/k7/ppp1p3/r2bP3/1K6 b - - 6 5</i>:
+     * <br>Here the best move is a mate in 1 (c3c2), the second best move's principal variation is check the king with the rook, opponent move is forced,
+     * then move back the rook to its initial position, opponent is forced again, then ... play the best move. It results in a mate in 3.
+     * <br>With two repetitions test, this mat is considered as a draw.
+     * @return true if the current position was already encountered in the board's history
+     */
     public static boolean isDoubleRepetition(Board board) {
-
         long zobrist = board.getState().getKey();
         BoardState[] states = board.getStates();
-        for (int i = board.getPly() - 1; i >= 0; i--) {
+        // No need to check the positions after the last half move clock reset as they are not reproducible
+        int lastReproductiblePly = board.getPly() - board.getState().getHalfMoveClock();
+        for (int i = board.getPly() - 2; i >= lastReproductiblePly; i=i-2) {
+            // decrement i by 2 as we can skip the positions where the player to move is not the current one
             if (states[i].getKey() == zobrist) {
                 return true;
             }
         }
         return false;
-
     }
 
+    /** Checks if the current position is a draw due to an <a href="https://en.wikipedia.org/wiki/Insufficient_material">insufficient material</a>
+     * (also known as dead) position.
+     * @return true if the current position is an insufficient material position
+     */
     public static boolean isInsufficientMaterial(Board board) {
         if (board.getPawns() != 0 || board.getRooks() != 0 || board.getQueens() != 0) {
             return false;
@@ -48,8 +84,17 @@ public class Draw {
                 && (Bits.count(blackPieces) == 0 || Bits.count(blackPieces) == 1);
     }
 
+    /** Checks if the current position is a draw due to the <a href="https://en.wikipedia.org/wiki/Fifty-move_rule">fifty-move rule</a>.
+     * @return true if the current position is a draw due to the fifty-move rule
+     */
     public static boolean isFiftyMoveRule(Board board) {
         return board.getState().getHalfMoveClock() >= 100;
     }
 
+    /** Checks if the board is a draw due to a <a href="https://en.wikipedia.org/wiki/Stalemate">stalemate</a>.
+     * @return true if the board is a draw due to a stalemate
+     */
+    public static boolean isStalemate(Board board, MoveGenerator moveGenerator) {
+        return !moveGenerator.isCheck(board, !board.isWhite()) && moveGenerator.generateMoves(board).isEmpty();
+    }
 }

--- a/src/main/java/com/kelseyde/calvin/board/Square.java
+++ b/src/main/java/com/kelseyde/calvin/board/Square.java
@@ -2,36 +2,84 @@ package com.kelseyde.calvin.board;
 
 import java.util.List;
 
-public class Square {
+/** A utility class about squares on a chess board. */
+public final class Square {
+    private Square() {
+        super();
+    }
 
+    /** The number of squares on a chess board. */
     public static final int COUNT = 64;
+    /** A bitboard with all squares set. */
     public static final long ALL = ~0L;
+    /** A bitboard with no squares set. */
     public static final long NONE = 0L;
+    /** A bitboard with all black squares set. */
+    public static final long BLACK = 0xAA55AA55AA55AA55L;
+    /** A bitboard with all white squares set. */
+    public static final long WHITE = 0x55AA55AA55AA55AAL;
 
+    /** Returns the bitbord of a square given its rank and file.
+     * @param rank the rank of the square
+     * @param file the file of the square
+     * @return the bitboard of the square
+    */
     public static int of(int rank, int file) {
         return (rank << 3) + file;
     }
 
+    /** Flips the rank of a square (flip vertically) <a href="https://www.chessprogramming.org/Flipping_Mirroring_and_Rotating">on the board</a>.
+     * <br><b>Warning</b>: this method makes no validation of the square index, passing an invalid index may produce unexpected results.
+     * @param sq the square index to flip
+     * @return the flipped square index
+    */
     public static int flipRank(int sq) {
         return sq ^ 56;
     }
 
+    /** Flips the file of a square (flip horizontally) <a href="https://www.chessprogramming.org/Flipping_Mirroring_and_Rotating">on the board</a>.
+     * <br><b>Warning</b>: this method makes no validation of the square index, passing an invalid index may produce unexpected results.
+     * @param sq the square index to flip
+     * @return the flipped square index
+    */
     public static int flipFile(int sq) {
         return sq ^ 7;
     }
 
+    /** Checks if a square is valid index.
+     * @param sq the square index to check
+     * @return true if the square is valid index, false otherwise
+    */
     public static boolean isValid(int sq) {
         return sq >= 0 && sq < Square.COUNT;
     }
 
+    /** Converts a square index to its <a href="https://en.wikipedia.org/wiki/Algebraic_notation_(chess)#Naming_the_squares">algebraic notation</a>.
+     * @param sq the square index to convert
+     * @return the algebraic notation of the square
+     * @throws IllegalArgumentException if the square index is invalid
+     * @see #isValid(int)
+    */
     public static String toNotation(int sq) {
+        if (!isValid(sq)) {
+            throw new IllegalArgumentException("Invalid square index: " + sq);
+        }
         return File.toNotation(sq) + Rank.toRankNotation(sq);
     }
 
+    /** Converts an <a href="https://en.wikipedia.org/wiki/Algebraic_notation_(chess)#Naming_the_squares">algebraic notation</a> to a square index.
+     * @param algebraic the algebraic notation to convert
+     * @return the square index of the algebraic notation
+     * @throws IllegalArgumentException if the algebraic notation is invalid
+    */
     public static int fromNotation(String algebraic) {
-        int xOffset = List.of('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h').indexOf(algebraic.charAt(0));
-        int yAxis = (Integer.parseInt(Character.valueOf(algebraic.charAt(1)).toString()) - 1) * 8;
-        return yAxis + xOffset;
+        if (algebraic.length() == 2) {
+            final int xOffset = List.of('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h').indexOf(algebraic.charAt(0));
+            final int yAxis = Integer.parseInt(Character.toString(algebraic.charAt(1))) - 1;
+            if (xOffset >= 0 && yAxis >= 0 && yAxis<8) {
+                return yAxis*8 + xOffset;
+            }
+        }
+        throw new IllegalArgumentException("Invalid algebraic notation: " + algebraic);
     }
-
 }

--- a/src/test/java/com/kelseyde/calvin/board/DrawTest.java
+++ b/src/test/java/com/kelseyde/calvin/board/DrawTest.java
@@ -1,0 +1,173 @@
+package com.kelseyde.calvin.board;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import com.kelseyde.calvin.movegen.MoveGenerator;
+import com.kelseyde.calvin.utils.TestUtils;
+import com.kelseyde.calvin.utils.notation.FEN;
+
+class DrawTest {
+	private MoveGenerator mg = new MoveGenerator();
+    
+    @Test
+    void testRepetitions() {
+        // No draw at all
+        String fen ="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        String[] moves = "d2d4 d7d5 g1f3 g8f6 g2g3 c7c6 f1g2 h7h6 e1g1 g7g6".split(" ");
+        Board board = build(fen, moves);
+        assertFalse(Draw.isDoubleRepetition(board));
+        assertFalse(Draw.isThreefoldRepetition(board));
+        assertFalse(Draw.isInsufficientMaterial(board));
+        assertFalse(Draw.isStalemate(board, mg));
+        assertFalse(Draw.isEffectiveDraw(board));
+        assertFalse(Draw.isDraw(board, mg));
+        
+        // Two repetitions
+        fen ="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        moves = "b1c3 b8c6 c3b1 c6b8".split(" ");
+        board = build(fen, moves);
+        assertTrue(Draw.isDoubleRepetition(board));
+        assertFalse(Draw.isThreefoldRepetition(board));
+        assertFalse(Draw.isInsufficientMaterial(board));
+        assertFalse(Draw.isStalemate(board, mg));
+        assertTrue(Draw.isEffectiveDraw(board));
+        assertFalse(Draw.isDraw(board, mg));
+        
+        // Three repetitions
+        fen ="rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
+        moves = "b1c3 b8c6 g1f3 g8f6 f3g1 f6g8 c3b1 c6b8 b1c3 b8c6 c3b1 c6b8".split(" ");
+        board = build(fen, moves);
+        assertTrue(Draw.isDoubleRepetition(board));
+        assertTrue(Draw.isThreefoldRepetition(board));
+        assertFalse(Draw.isInsufficientMaterial(board));
+        assertFalse(Draw.isStalemate(board, mg));
+        assertTrue(Draw.isEffectiveDraw(board));
+        assertTrue(Draw.isDraw(board, mg));
+    }
+    
+    @Test
+    void testStaleMate() {
+        // staleMate
+        Board board = FEN.toBoard("7k/3Q4/8/8/2B5/8/8/4K3 b - - 0 1");
+        assertFalse(Draw.isDoubleRepetition(board));
+        assertFalse(Draw.isThreefoldRepetition(board));
+        assertFalse(Draw.isInsufficientMaterial(board));
+        assertTrue(Draw.isStalemate(board, mg));
+        assertFalse(Draw.isEffectiveDraw(board));
+        assertTrue(Draw.isDraw(board, mg));
+        
+        // Black seem stale mated ... but white to move.
+        board = FEN.toBoard("7k/3Q4/8/8/2B5/8/8/4K3 w - - 0 1");
+        assertFalse(Draw.isDoubleRepetition(board));
+        assertFalse(Draw.isThreefoldRepetition(board));
+        assertFalse(Draw.isInsufficientMaterial(board));
+        assertFalse(Draw.isStalemate(board, mg));
+        assertFalse(Draw.isEffectiveDraw(board));
+        assertFalse(Draw.isDraw(board, mg));
+
+        // Mate.
+        board = FEN.toBoard("6Qk/8/8/8/2B5/8/8/4K3 b - - 0 1");
+        assertFalse(Draw.isDoubleRepetition(board));
+        assertFalse(Draw.isThreefoldRepetition(board));
+        assertFalse(Draw.isInsufficientMaterial(board));
+        assertFalse(Draw.isStalemate(board, mg));
+        assertFalse(Draw.isEffectiveDraw(board));
+        assertFalse(Draw.isDraw(board, mg));
+    }
+    
+    @Test
+    void testInsufficientMaterial() {
+        // Draw positions
+        // Nothing but kings
+        assertDraw(FEN.toBoard("8/7k/8/8/8/8/8/3K4 b - - 0 1"));
+        // King vs bishop
+        assertDraw(FEN.toBoard("7k/8/8/8/2B5/8/8/4K3 b - - 0 1"));
+        // King vs knight
+        assertDraw(FEN.toBoard("8/7k/8/8/8/6n1/8/3K4 b - - 0 1"));
+        // Bishop vs bishop of the same color
+        assertDraw (FEN.toBoard("8/3K4/k7/8/3b4/8/3B4/8 b - - 0 1"));
+        // Three bishops of the same cell's color vs king
+        assertDraw(FEN.toBoard("8/3K2B1/k7/8/8/8/3B4/8 b - - 0 1"));
+
+        // Not draw positions
+        // Two bishops of different cell's colors vs king
+        assertNotDraw(FEN.toBoard("8/3K4/k5B1/8/8/8/3B4/8 b - - 0 1"));
+        // King vs pawn
+        assertNotDraw(FEN.toBoard("7k/8/8/8/2P5/8/8/4K3 b - - 0 1"));
+        // King vs rook
+        assertNotDraw(FEN.toBoard("8/5k2/8/8/8/1K6/5r2/8 w - - 0 1"));
+        // king vs queen
+        assertNotDraw(FEN.toBoard("1k6/8/5q2/2K5/8/8/8/8 w - - 0 1"));
+        // Three knights
+        assertNotDraw(FEN.toBoard("3K4/8/1k6/3nnn2/8/8/8/8 b - - 0 1"));
+        // King vs knight and bishop
+        assertNotDraw(FEN.toBoard("8/3K4/k7/3N4/8/2B5/8/8 w - - 0 1"));
+
+        // Draw if opponent does not want to loose (see https://rustic-chess.org/board_functionality/detecting_fide_draws.html#draw-by-insufficient-material-rule)
+        // King vs two knights (see https://en.wikipedia.org/wiki/Two_knights_endgame)
+        assertDrawWithOpponentHelp(FEN.toBoard("6k1/8/3N1NK1/8/8/8/8/8 w - - 1 2"));
+        // Bishop vs bishop of opposite color
+        assertDrawWithOpponentHelp(FEN.toBoard("8/3K4/k7/8/3b4/8/4B3/8 b - - 0 1"));
+        // knight vs knight
+        assertDrawWithOpponentHelp(FEN.toBoard("8/8/8/5k2/2n5/7N/2K5/8 b - - 0 1"));
+        // Bishop vs knight
+        assertDrawWithOpponentHelp(FEN.toBoard("7k/1n6/8/8/2B5/8/8/4K3 b - - 0 1"));
+        // King vs 2 knights
+        assertDrawWithOpponentHelp(FEN.toBoard("8/1n6/4n3/8/8/2k5/8/4K3 b - - 0 1"));
+    }
+    
+    private void assertDraw(Board board) {
+        assertBool(board, "isInsufficientMaterial", Draw::isInsufficientMaterial, true);
+        assertBool(board, "isInsufficientMaterialFIDERule", Draw::isInsufficientMaterialFIDERule, true);
+        assertBool(board, "isEffectiveDraw", Draw::isEffectiveDraw, true);
+        assertBool(board, "isDraw", b -> Draw.isDraw(b, mg), true);
+    }
+    
+    private void assertDrawWithOpponentHelp(Board board) {
+        assertBool(board, "isInsufficientMaterial", Draw::isInsufficientMaterial, true);
+        assertBool(board, "isInsufficientMaterialFIDERule", Draw::isInsufficientMaterialFIDERule, false);
+        assertBool(board, "isEffectiveDraw", Draw::isEffectiveDraw, true);
+        assertBool(board, "isDraw", b -> Draw.isDraw(b, mg), false);
+    }
+    
+    private void assertNotDraw(Board board) {
+        assertBool(board, "isInsufficientMaterial", Draw::isInsufficientMaterial, false);
+        assertBool(board, "isInsufficientMaterialFIDERule", Draw::isInsufficientMaterialFIDERule, false);
+        assertBool(board, "isEffectiveDraw", Draw::isEffectiveDraw, false);
+        assertBool(board, "isDraw", b -> Draw.isDraw(b, mg), false);
+    }
+    
+    private void assertBool(Board board, String methodName, Predicate<Board> predicate, boolean expected) {
+        assertEquals(expected, predicate.test(board), "Problem at Draw."+methodName+" for FEN "+FEN.toFEN(board));
+    }
+    
+    @Test
+    void fiftyMoveRuleTest() {
+        Board board = FEN.toBoard("8/8/4k3/4p3/4KP2/8/8/8 b - - 99 148");
+        assertFalse(Draw.isFiftyMoveRule(board));
+        assertFalse(Draw.isEffectiveDraw(board));
+        assertFalse(Draw.isDraw(board, mg));
+        board = FEN.toBoard("8/8/3k4/4p3/4KP2/8/8/8 w - - 100 149");
+        assertTrue(Draw.isFiftyMoveRule(board));
+        assertTrue(Draw.isEffectiveDraw(board));
+        assertTrue(Draw.isDraw(board, mg));
+    }
+    
+    private Board build(String fen, String[] moves) {
+        final Board board = Board.from(fen);
+        Arrays.stream(moves).forEach(m -> play(board, m));
+        return board;
+    }
+
+    private void play(Board board, String uci) {
+        Move mv = TestUtils.getLegalMove(board, Move.fromUCI(uci));
+        assertTrue(mg.isLegal(board, mv));
+        board.makeMove(mv);
+    }
+
+}

--- a/src/test/java/com/kelseyde/calvin/board/SquareTest.java
+++ b/src/test/java/com/kelseyde/calvin/board/SquareTest.java
@@ -1,0 +1,41 @@
+package com.kelseyde.calvin.board;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import static com.kelseyde.calvin.board.Square.*;
+
+import org.junit.jupiter.api.Test;
+
+class SquareTest {
+
+    @Test
+    void testBlackAndWhite() {
+        
+        assertEquals(0, WHITE & BLACK);
+        assertEquals(ALL, WHITE | BLACK);
+        
+        assertFalse(isWhite("a1"));
+        assertTrue(isWhite("h1"));
+        assertTrue(isWhite("a2"));
+        assertFalse(isWhite("d2"));
+        assertTrue(isWhite("g6"));
+        assertFalse(isWhite("h8"));
+    }
+    
+    private boolean isWhite(String notation) {
+        long bit = Bits.of(fromNotation(notation));
+        return (bit & WHITE) == bit;
+    }
+
+    @Test
+    void testAlgebraicNotation() {
+        assertEquals(0, fromNotation("a1"));
+        assertEquals(63, fromNotation("h8"));
+        assertThrows(IllegalArgumentException.class, () -> fromNotation("i1"));
+        assertThrows(IllegalArgumentException.class, () -> fromNotation("a9"));
+        assertThrows(IllegalArgumentException.class, () -> fromNotation("a"));
+        assertThrows(IllegalArgumentException.class, () -> fromNotation("ab"));
+        assertThrows(IllegalArgumentException.class, () -> fromNotation("1a"));
+    }
+
+}


### PR DESCRIPTION
Hello Dan,

I made the following changes in the `Draw` class:
- I added javadoc comments
- I optimized `isThreefoldRepetition` and `isDoubleRepetition` methods. These methods no longer check for equality of positions whose color that should play is not the same as the one being searched.
 This search is also limited to positions that occurred after the last irreversible move (when a pawn is moved or a capture is made, positions prior to that move can no longer occur).
- I added the `isStaleMate` method.
- I made some changes to the `isInsufficientMaterial` method, but first of all, I'm not sure I understood its semantics.
I assumed that it should return true if the position is a draw unless there is a blunder error. Typically a knight versus knight position should return true even if it allows checkmate (see https://rustic-chess.org/board_functionality/detecting_fide_draws.html#draw-by-insufficient-material-rule).
Forgive me if I didn't understand anything.  
Assuming I understood, I fixed bugs (or behaviour that seemed strange to me) in `isInsufficientMaterial` method:
    - Positions with a knight against a bishop were not considered as draw (example: 7k/1n6/8/8/2B5/8/8/4K3 b - - 0 1).
    - Positions with a king and bishops of same cell's colors against a single king were not considered as a draw (example: 8/3K4/k7/8/3b4/8/3B4/8 b - - 0 1). I agree this is not very common (It requires a player promoted a pawn to a bishop).
- I added `isInsufficientMaterialFIDERule` method which implements the FIDE rule: It means that positions where the opponent can only win with an opponent's mistake are not considered as draws (example opposite-colored bishop 8/3K4/k7/8/3b4/8/4B3/8 b - - 0 1).
I think it will be useful for anyone that want to implement a GUI or the XBoard protocol.
- I added the `isDraw` method that checks for stale mates, fifty move rule, three fold repetition and insufficient material with the FIDE rule. I think this is how GUI declare draw without any player claiming for it.

To achieve previous points, I needed a way to check if a player has the bishop pair.
So, I added the method `hasBishopPair(boolean)` to the `Board` class. I would also be useful for the ones who want to take bishop pair into account in their evaluation functions.

And to implement `Board.hasBishopPair(boolean)`, I needed constants to identify white squares.
So I made the following changes the `Square` class
  - I added two constants to identify white and black cells.
  - I added javadoc.
  - Algebraic notation related methods now throw `IllegalArgumentException` when arguments are wrong.

Best regards,
Jean-Marc
PS : I added tests for all this stuff.