### PR TITLE
Adds toString methods to Board & Bits, deprecates print methods of these classes and adds BoardPrinter class

### DIFF
--- a/src/main/java/com/kelseyde/calvin/board/Bits.java
+++ b/src/main/java/com/kelseyde/calvin/board/Bits.java
@@ -73,9 +73,8 @@ public class Bits {
      * Prints the bitboard to the standard output.
      *  Use {@link BoardPrinter#print(long)} or {@link #toString(long)} instead.
      */
-    public static void print(long bb) {
-    	new BoardPrinter(System.out::println).print(bb);
-    	System.out.println();
+    public static void print(long board) {
+    	System.out.println(toString(board));
     }
     
     public static String toString(long board) {

--- a/src/main/java/com/kelseyde/calvin/board/Bits.java
+++ b/src/main/java/com/kelseyde/calvin/board/Bits.java
@@ -67,15 +67,6 @@ public class Bits {
         }
         return squares;
     }
-
-    @Deprecated(forRemoval = true)
-    /** @deprecated
-     * Prints the bitboard to the standard output.
-     *  Use {@link BoardPrinter#print(long)} or {@link #toString(long)} instead.
-     */
-    public static void print(long board) {
-    	System.out.println(toString(board));
-    }
     
     public static String toString(long board) {
         final StringBuilder builder = new StringBuilder();

--- a/src/main/java/com/kelseyde/calvin/board/Bits.java
+++ b/src/main/java/com/kelseyde/calvin/board/Bits.java
@@ -68,22 +68,20 @@ public class Bits {
         return squares;
     }
 
+    @Deprecated(forRemoval = true)
+    /** @deprecated
+     * Prints the bitboard to the standard output.
+     *  Use {@link BoardPrinter#print(long)} or {@link #toString(long)} instead.
+     */
     public static void print(long bb) {
-
-        for (int rank = 7; rank >= 0; --rank) {
-            System.out.print(" +---+---+---+---+---+---+---+---+\n");
-
-            for (int file = 0; file < 8; ++file) {
-                boolean piece = (bb & (Bits.of(Square.of(rank, file)))) != 0;
-                System.out.print(" | " + (piece ? '1' : ' '));
-            }
-
-            System.out.print(" | "  + (rank + 1) + "\n");
-        }
-
-        System.out.print(" +---+---+---+---+---+---+---+---+\n");
-        System.out.print("   a   b   c   d   e   f   g   h\n\n");
-
+    	new BoardPrinter(System.out::println).print(bb);
+    	System.out.println();
     }
-
+    
+    public static String toString(long board) {
+        final StringBuilder builder = new StringBuilder();
+        new BoardPrinter(BoardPrinter.getConsumer(builder)).print(board);
+        builder.deleteCharAt(builder.length()-1);
+        return builder.toString();
+    }
 }

--- a/src/main/java/com/kelseyde/calvin/board/Board.java
+++ b/src/main/java/com/kelseyde/calvin/board/Board.java
@@ -641,30 +641,22 @@ public class Board {
         return newBoard;
     }
 
+    @Deprecated(forRemoval = true)
+    /** @deprecated
+     * Prints the board to the standard output.
+     *  Use {@link BoardPrinter#print(Board))} or {@link #toString()} instead.
+     */
     public void print() {
-
-        for (int rank = 7; rank >= 0; --rank) {
-            System.out.print(" +---+---+---+---+---+---+---+---+\n");
-
-            for (int file = 0; file < 8; ++file) {
-                int sq = Square.of(rank, file);
-                Piece piece = pieceAt(sq);
-                if (piece == null) {
-                    System.out.print(" |  ");
-                    continue;
-                }
-                boolean white = (getWhitePieces() & Bits.of(sq)) != 0;
-                System.out.print(" | " + (white ? piece.code().toUpperCase() : piece.code()));
-            }
-
-            System.out.print(" | " + (rank + 1) + "\n");
-        }
-
-        System.out.print(" +---+---+---+---+---+---+---+---+\n");
-        System.out.print("   a   b   c   d   e   f   g   h\n\n");
-
-        System.out.print((white ? "White" : "Black") + " to move\n");
-
+        System.out.println(this);
     }
 
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        new BoardPrinter(BoardPrinter.getConsumer(builder)).print(this);
+        builder.append('\n');
+        builder.append(white ? "White" : "Black");
+        builder.append(" to move");
+        return builder.toString();
+    }
 }

--- a/src/main/java/com/kelseyde/calvin/board/Board.java
+++ b/src/main/java/com/kelseyde/calvin/board/Board.java
@@ -641,15 +641,6 @@ public class Board {
         return newBoard;
     }
 
-    @Deprecated(forRemoval = true)
-    /** @deprecated
-     * Prints the board to the standard output.
-     *  Use {@link BoardPrinter#print(Board))} or {@link #toString()} instead.
-     */
-    public void print() {
-        System.out.println(this);
-    }
-
     @Override
     public String toString() {
         final StringBuilder builder = new StringBuilder();

--- a/src/main/java/com/kelseyde/calvin/board/BoardPrinter.java
+++ b/src/main/java/com/kelseyde/calvin/board/BoardPrinter.java
@@ -57,8 +57,8 @@ public class BoardPrinter {
 		return white ? piece.code().toUpperCase() : piece.code();
 	}
 	
-	private String getBitCell(Long bitBoard, int sq) {
-        boolean piece = (bitBoard & (Bits.of(sq))) != 0;
+	private String getBitCell(Long board, int sq) {
+        boolean piece = (board & (Bits.of(sq))) != 0;
         return piece ? "1" : " ";
     }
 

--- a/src/main/java/com/kelseyde/calvin/board/BoardPrinter.java
+++ b/src/main/java/com/kelseyde/calvin/board/BoardPrinter.java
@@ -1,0 +1,97 @@
+package com.kelseyde.calvin.board;
+
+import java.util.function.Consumer;
+
+/** A class for printing chess boards or bitboards */
+public class BoardPrinter {
+	@FunctionalInterface
+	private interface CellBuilder<T> {
+		String get(T board, int square);
+	}
+
+	static final String BORDER = "+---+---+---+---+---+---+---+---+";
+
+	private boolean withCoordinates = true;
+	private final Consumer<String> out;
+
+	/**
+	 * Creates a new {@link BoardPrinter} instance.
+	 * @param out the consumer to call when a line is printed
+	 * @throws IllegalArgumentException if {@code out} is {@code null}
+	 */
+	public BoardPrinter(Consumer<String> out) {
+		if (out==null) {
+			throw new IllegalArgumentException();
+		}
+		this.out = out;
+	}
+	
+	/** Sets the printer to print with or without coordinates.
+	 * @param withCoordinates the new value. Default value is true
+	 * @return this instance. */
+	public BoardPrinter withCoordinates(boolean withCoordinates) {
+		this.withCoordinates = withCoordinates;
+		return this;
+	}
+
+	/** Prints a board.
+	 * @param board the board to print
+	 */
+	public void print(Board board) {
+		print(board, this::getPieceCell);
+ 	}
+
+	/** Prints a bitboard.
+	 * @param bitBoard the bitboard to print
+	 */
+	public void print(long bitBoard) {
+		print(bitBoard, this::getBitCell);
+ 	}
+
+	private String getPieceCell(Board board, int square) {
+		final Piece piece = board.pieceAt(square);
+		if (piece == null) {
+			return " ";
+		}
+		final boolean white = (board.getWhitePieces() & Bits.of(square)) != 0;
+		return white ? piece.code().toUpperCase() : piece.code();
+	}
+	
+	private String getBitCell(Long bitBoard, int sq) {
+        boolean piece = (bitBoard & (Bits.of(sq))) != 0;
+        return piece ? "1" : " ";
+    }
+
+	private <T>void print(T board, CellBuilder<T> cellBuilder) {
+		for (int rank = 7; rank >= 0; --rank) {
+			out.accept(BORDER);
+			final StringBuilder builder = new StringBuilder();
+			for (int file = 0; file < 8; ++file) {
+				builder.append("| ");
+				builder.append(cellBuilder.get(board, Square.of(rank, file)));
+				builder.append(' ');
+			}
+			builder.append('|');
+			if (withCoordinates) {
+				builder.append(' ');
+				builder.append(rank + 1);
+			}
+			out.accept(builder.toString());
+		}
+		out.accept(BORDER);
+		if (withCoordinates) {
+			out.accept("  a   b   c   d   e   f   g   h");
+		}
+	}
+	
+	/** Returns a consumer that appends strings to a StringBuilder inserting a newline after each string.
+	 * @param builder the StringBuilder to append to
+	 * @return a String consumer.
+	 */
+	public static Consumer<String> getConsumer(StringBuilder builder) {
+	    return s -> {
+            builder.append(s);
+            builder.append('\n');
+	    };
+	}
+}

--- a/src/main/java/com/kelseyde/calvin/board/Move.java
+++ b/src/main/java/com/kelseyde/calvin/board/Move.java
@@ -183,17 +183,17 @@ public record Move(short value) {
     /**
      * Generates a UCI representation of a move (e.g. "e2e4").
      * @param move The move
-     * @return The UCI notation
+     * @return The UCI notation ("-" if move is null)
      */
     public static String toUCI(Move move) {
         if (move == null) return "-";
         final String notation = Square.toNotation(move.from()) + Square.toNotation(move.to());
         final Piece promoPiece = move.promoPiece();
-        return promoPiece == null ? notation : notation + promoPiece.code();
+		return promoPiece == null ? notation : notation + promoPiece.code();
     }
 
-    @Override
-    public String toString() {
-        return toUCI(this);
-    }
+	@Override
+	public String toString() {
+		return toUCI(this);
+	}
 }

--- a/src/main/java/com/kelseyde/calvin/board/Move.java
+++ b/src/main/java/com/kelseyde/calvin/board/Move.java
@@ -189,11 +189,11 @@ public record Move(short value) {
         if (move == null) return "-";
         final String notation = Square.toNotation(move.from()) + Square.toNotation(move.to());
         final Piece promoPiece = move.promoPiece();
-		return promoPiece == null ? notation : notation + promoPiece.code();
+        return promoPiece == null ? notation : notation + promoPiece.code();
     }
 
-	@Override
-	public String toString() {
-		return toUCI(this);
-	}
+    @Override
+    public String toString() {
+        return toUCI(this);
+    }
 }

--- a/src/test/java/com/kelseyde/calvin/board/BoardPrinterTest.java
+++ b/src/test/java/com/kelseyde/calvin/board/BoardPrinterTest.java
@@ -1,0 +1,71 @@
+package com.kelseyde.calvin.board;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.kelseyde.calvin.utils.notation.FEN;
+
+import java.util.ArrayList;
+import java.util.List;
+
+class BoardPrinterTest {
+    @Test
+    void testPrintBitBoard() {
+        final List<String> result = new ArrayList<>();
+        final BoardPrinter printer = new BoardPrinter(result::add);
+        printer.print(Bits.of(Square.of(0, 0)));
+        assertEquals(18, result.size());
+        // Test borders
+        for (int i=0;i<17;i=i+2) {
+            assertEquals(BoardPrinter.BORDER, result.get(i));
+        }
+        assertEquals("  a   b   c   d   e   f   g   h", result.get(result.size()-1));
+        // Test lines that corresponds to the bitboard
+        for (int i=1;i<=13;i=i+4) {
+            assertEquals("|   |   |   |   |   |   |   |   | "+Integer.toString((17-i)/2), result.get(i));
+        }
+        assertEquals("| 1 |   |   |   |   |   |   |   | 1", result.get(15));
+        
+        // Test no coordinates
+        result.clear();
+        printer.withCoordinates(false).print(Square.ALL);
+        assertEquals(17, result.size());
+        // Test borders
+        for (int i=0;i<17;i=i+2) {
+            assertEquals(BoardPrinter.BORDER, result.get(i));
+        }
+        // Test there's no coordinates and lines starts right
+        for (int i=1;i<17;i=i+2) {
+            assertTrue(result.get(i).startsWith("| 1 | 1 |"));
+            assertEquals(BoardPrinter.BORDER.length(), result.get(i).length());
+        }
+    }
+    
+    @Test
+    void testPrintBoard() {
+        final List<String> result = new ArrayList<>();
+        final BoardPrinter printer = new BoardPrinter(result::add).withCoordinates(false);
+        Board board = Board.from(FEN.STARTPOS);
+        printer.print(board);
+        assertEquals(17, result.size());
+        // Test borders
+        for (int i=0;i<17;i=i+2) {
+            assertEquals(BoardPrinter.BORDER, result.get(i));
+        }
+        // Test contents
+        assertEquals("| r | n | b | q | k | b | n | r |", result.get(1));
+        assertEquals("| p | p | p | p | p | p | p | p |", result.get(3));
+        for (int i=5;i<=11;i=i+2) {
+            assertEquals("|   |   |   |   |   |   |   |   |", result.get(i));
+        }
+        assertEquals("| P | P | P | P | P | P | P | P |", result.get(13));
+        assertEquals("| R | N | B | Q | K | B | N | R |", result.get(15));
+    }
+    
+    @Test
+    void testWrongArguments() {
+        assertThrows(IllegalArgumentException.class, () -> new BoardPrinter(null));
+    }
+
+}


### PR DESCRIPTION
Hello Dan,
The first goal of this PR is to tag the `print` methods of `Board` and `Bits` as deprecated.
I added two replacements:
- `toString` methods that return what was printed by the `print`methods.
- A `BoardPrinter` class that is able to generate the lines that correspond to a `Board` or a `long` (a bitboard). It allows the user to optionally omit the coordinates in the output. Its constructor requires a `Consumer<String>`. If you pass `System.out::println`, it prints to standard output, but you can pass another consumer to send the lines wherever you want.

In my opinion, the print methods should be removed now, let me known if you agree.

Regards,
Jean-Marc