### PR TITLE
Fen fixes and BoardBuilder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,17 @@
         </profile>
     </profiles>
 
+    <repositories>
+        <!-- Required to fetch snapshots from sonatype -->
+        <repository>
+            <id>sonatype-snapshots</id>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -55,17 +55,6 @@
         </profile>
     </profiles>
 
-    <repositories>
-        <!-- Required to fetch snapshots from sonatype -->
-        <repository>
-            <id>sonatype-snapshots</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -76,7 +65,7 @@
         <dependency>
             <groupId>com.fathzer</groupId>
             <artifactId>chess-test-utils</artifactId>
-            <version>0.0.1-SNAPSHOT</version>
+            <version>0.0.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,13 @@
             <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fathzer</groupId>
+            <artifactId>chess-test-utils</artifactId>
+            <version>0.0.1-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
-
     <build>
         <resources>
             <resource>

--- a/src/main/java/com/kelseyde/calvin/board/BoardBuilder.java
+++ b/src/main/java/com/kelseyde/calvin/board/BoardBuilder.java
@@ -1,0 +1,441 @@
+package com.kelseyde.calvin.board;
+
+import static com.kelseyde.calvin.board.Piece.*;
+
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+/** A chess board builder. */
+public class BoardBuilder {
+    private static class StartPositionBuilder {
+        private static final Piece[][] KRN = {
+            {KNIGHT, KNIGHT, ROOK, KING, ROOK},
+            {KNIGHT, ROOK, KNIGHT, KING, ROOK},
+            {KNIGHT, ROOK, KING, KNIGHT, ROOK},
+            {KNIGHT, ROOK, KING, ROOK, KNIGHT},
+            {ROOK, KNIGHT, KNIGHT, KING, ROOK},
+            {ROOK, KNIGHT, KING, KNIGHT, ROOK},
+            {ROOK, KNIGHT, KING, ROOK, KNIGHT},
+            {ROOK, KING, KNIGHT, KNIGHT, ROOK},
+            {ROOK, KING, KNIGHT, ROOK, KNIGHT},
+            {ROOK, KING, ROOK, KNIGHT, KNIGHT},
+        };
+
+        private static void fillFromPositionNumber(BoardBuilder builder, int position) {
+            if (position<0 || position>=960) {
+                throw new IllegalArgumentException();
+            }
+            // Add pawns
+            IntStream.range(0, 8).forEach(i->builder.addPiece(Square.of(1, i), PAWN, true));
+            IntStream.range(0, 8).forEach(i->builder.addPiece(Square.of(6, i), PAWN, false));
+            
+            // Add bishops
+            final int whiteCellBishop = 1+(position % 4)*2;
+            builder.addPiece(whiteCellBishop, BISHOP, true);
+            builder.addPiece(Square.flipRank(whiteCellBishop), BISHOP, false);
+            position = position/4;
+            final int blackCellBishop = (position % 4)*2;
+            builder.addPiece(blackCellBishop, BISHOP, true);
+            builder.addPiece(Square.flipRank(blackCellBishop), BISHOP, false);
+            position = position/4;
+            
+            // We will maintain a list of free cells in order to position the remaining piece
+            final List<Integer> freeCells = IntStream.range(0, 8).mapToObj(Integer::valueOf).collect(Collectors.toList());
+            freeCells.remove(Integer.valueOf(whiteCellBishop));
+            freeCells.remove(Integer.valueOf(Square.flipFile(whiteCellBishop)));
+            // Add queens
+            final int queenPosition = freeCells.remove(position%6);
+            builder.addPiece(Square.of(0, queenPosition), QUEEN, true);
+            builder.addPiece(Square.of(7, queenPosition), QUEEN, false);
+            
+            // Add rest of pieces
+            addKRN(builder, freeCells, KRN[position/6], true);
+            addKRN(builder, freeCells, KRN[position/6], false);
+
+            // add castling rights
+            builder.addCastlingRights(true, true);
+            builder.addCastlingRights(true, false);
+            builder.addCastlingRights(false, true);
+            builder.addCastlingRights(false, false);
+        }
+        
+        private static void addKRN(BoardBuilder builder, List<Integer> positions, Piece[] krn, boolean white) {
+            IntStream.range(0, positions.size()).forEach(i -> builder.addPiece(Square.of(white?0:7, positions.get(i)), krn[i], white));
+        }        
+    }
+
+    private static final class CastlingRights {
+        private static final int OUTER_MOST_ROOK = Integer.MAX_VALUE;
+        private static final int NO_RIGHT = -1;
+        private int whiteKingsideFile = NO_RIGHT;
+        private int whiteQueensideFile = NO_RIGHT;
+        private int blackKingsideFile = NO_RIGHT;
+        private int blackQueensideFile = NO_RIGHT;
+
+        private void add(boolean white, boolean kingside, int file) {
+            if (white) {
+                if (kingside) whiteKingsideFile = file;
+                else whiteQueensideFile = file;
+            } else {
+                if (kingside) blackKingsideFile = file;
+                else blackQueensideFile = file;
+            }
+        }
+
+        private boolean isEmpty() {
+            return whiteKingsideFile == NO_RIGHT &&
+                   whiteQueensideFile == NO_RIGHT &&
+                   blackKingsideFile == NO_RIGHT &&
+                   blackQueensideFile == NO_RIGHT;
+        }
+        
+        private boolean colorHasCastling(boolean white) {
+            if (white) {
+                return whiteKingsideFile!=NO_RIGHT || whiteQueensideFile!=NO_RIGHT;
+            } else {
+                return blackKingsideFile!=NO_RIGHT || blackQueensideFile!=NO_RIGHT;
+            }
+        }
+
+        private boolean bothColorsHasSideCastling(boolean kindSide) {
+            if (kindSide) {
+                return whiteKingsideFile!=NO_RIGHT && blackKingsideFile!=NO_RIGHT;
+            } else {
+                return whiteQueensideFile!=NO_RIGHT && blackQueensideFile!=NO_RIGHT;
+            }
+        }
+
+        private int get(boolean white, boolean kingside) {
+            if (white) {
+                return kingside ? whiteKingsideFile : whiteQueensideFile;
+            } else {
+                return kingside ? blackKingsideFile : blackQueensideFile;
+            }
+        }
+    }
+    
+    private static class BitMaps {
+        private long whitePawns = 0L;
+        private long whiteKnights = 0L;
+        private long whiteBishops = 0L;
+        private long whiteRooks = 0L;
+        private long whiteQueens = 0L;
+        private long whiteKing = 0L;
+        private long blackPawns = 0L;
+        private long blackKnights = 0L;
+        private long blackBishops = 0L;
+        private long blackRooks = 0L;
+        private long blackQueens = 0L;
+        private long blackKing = 0L;
+        private final long whitePieces;
+        private final long blackPieces;
+        
+        private BitMaps(Piece[] pieceList, long whitePieces) {
+            for (int i = 0; i < pieceList.length; i++) {
+                final Piece piece = pieceList[i];
+                if (piece!=null) {
+                    final long squareBit = Bits.of(i);
+                    addPiece(squareBit, piece, (whitePieces & squareBit) !=0);
+                }
+            }
+            this.whitePieces = whitePawns | whiteKnights | whiteBishops | whiteRooks | whiteQueens | whiteKing;
+            if (whitePieces != this.whitePieces) {
+                throw new IllegalArgumentException();
+            }
+            blackPieces = blackPawns | blackKnights | blackBishops | blackRooks | blackQueens | blackKing;
+        }
+        
+        private void addPiece(long squareBit, Piece piece, boolean white) {
+            if (white) {
+                switch (piece) {
+                    case PAWN -> whitePawns |= squareBit;
+                    case KNIGHT -> whiteKnights |= squareBit;
+                    case BISHOP -> whiteBishops |= squareBit;
+                    case ROOK -> whiteRooks |= squareBit;
+                    case QUEEN -> whiteQueens |= squareBit;
+                    case KING -> whiteKing |= squareBit;
+                }
+            } else {
+                switch (piece) {
+                    case PAWN -> blackPawns |= squareBit;
+                    case KNIGHT -> blackKnights |= squareBit;
+                    case BISHOP -> blackBishops |= squareBit;
+                    case ROOK -> blackRooks |= squareBit;
+                    case QUEEN -> blackQueens |= squareBit;
+                    case KING -> blackKing |= squareBit;
+                }
+            }
+        }
+        
+        private int kingSquare(boolean white) {
+            final long kings = white ? whiteKing : blackKing;
+            final long pieces = getPieces(white);
+            return Bits.next(kings & pieces);
+        }
+        
+        private long getPieces(boolean white) {
+            return white ? whitePieces : blackPieces;
+        }
+
+        private void fill(Board board) {
+            board.setPawns(whitePawns | blackPawns);
+            board.setKnights(whiteKnights | blackKnights);
+            board.setBishops(whiteBishops | blackBishops);
+            board.setRooks(whiteRooks | blackRooks);
+            board.setQueens(whiteQueens | blackQueens);
+            board.setKings(whiteKing | blackKing);
+            board.setWhitePieces(whitePieces);
+            board.setBlackPieces(blackPieces);
+        }
+    }
+
+    private static final Random RANDOM = new Random(System.currentTimeMillis());
+
+    private final ChessVariant variant;
+    // The added pieces
+    private Piece[] pieceList = new Piece[Square.COUNT];
+    // A bitmap of white added pieces. If a piece is in pieceList and its bit is 1, it is white
+    private long whitePieces = 0L;
+    private int enPassantFile = -1;
+    private int fiftyMoveCounter = 0;
+    private CastlingRights castlingRights = new CastlingRights();
+    private boolean whiteToMove = true;
+    
+    /** Creates a new standard board initialized with the standard starting position.
+     * @return the board
+     */
+    public static Board newStandard() {
+        BoardBuilder builder = new BoardBuilder(ChessVariant.STANDARD);
+        StartPositionBuilder.fillFromPositionNumber(builder, 518);
+        return builder.build();
+    }
+    
+    /** Creates a new <a href="https://en.wikipedia.org/wiki/Chess960">Fischer random board</a> initialized with a random starting position.
+     * @return the board
+     */
+    public static Board newFischerRandom() {
+        return newFischerRandom(RANDOM.nextInt(960));
+    }
+
+   /** Creates a new <a href="https://en.wikipedia.org/wiki/Chess960">Fischer random board</a> initialized with a specified starting position.
+     * @param positionId the position id in <a href="https://en.wikipedia.org/wiki/Fischer_random_chess_numbering_scheme">Fischer random chess numbering scheme</a>
+     * @return the board
+     */
+    public static Board newFischerRandom(int positionId) {
+        BoardBuilder builder = new BoardBuilder(ChessVariant.CHESS960);
+        StartPositionBuilder.fillFromPositionNumber(builder, positionId);
+        return builder.build();
+    }
+
+    /** Creates a new board builder.
+     * @param variant the variant of the board
+     */
+    public BoardBuilder(ChessVariant variant) {
+        if (variant==null) {
+            throw new IllegalArgumentException();
+        }
+        this.variant = variant;
+    }
+
+    /** Adds, removes or replace a piece to the board at the given square.
+     * <br>If there's already a piece at the provided square, it is replaced.
+     * <br>By default, the built board contains no pieces.
+     * @param square the square to add the piece to
+     * @param piece the piece to add, or null to remove the piece
+     * @param white if the piece is white (ignored if the piece is null)
+     */
+    public void addPiece(int square, Piece piece, boolean white) {
+        final long squareBit = Bits.of(square);
+        if (pieceList[square] != null) {
+            // piece replacement -> remove the piece from the white pieces list
+            whitePieces = whitePieces ^ squareBit;
+        }
+        pieceList[square] = piece;
+        if (white && piece != null) {
+            whitePieces = whitePieces | squareBit;
+        }
+    }
+
+    /** Sets the white to move flag.
+     * <br>Defaults to true
+     * @param whiteToMove the white to move flag
+     */
+    public void setWhiteToMove(boolean whiteToMove) {
+        this.whiteToMove = whiteToMove;
+    }
+
+    /** Adds a standard castling right.
+     * <br>A standard castling right is the right to castle with the outermost rook. This is the only castling allowed with standard chess.
+     * <br>Defaults to no castling allowed.
+     * @param white the color to add the castling rights to
+     * @param kingSide true for king side castling, false for queen side castling.
+     * @see #addCastlingRights(boolean, boolean, int)
+     */
+    public void addCastlingRights(boolean white, boolean kingSide) {
+        this.castlingRights.add(white, kingSide, CastlingRights.OUTER_MOST_ROOK);
+    }
+
+    /** Adds a castling right with a specified rook file.
+     * <br>This castling is essential to describe castling with an inner rook in <a href="https://en.wikipedia.org/wiki/X-FEN#Encoding_castling_rights">Chess960</a>.
+     * <br>Defaults to no castling allowed.
+     * @param white the color to add the castling rights to
+     * @param kingSide true for king side castling, false for queen side castling.
+     * @param file the rook's file.
+     * @see #addCastlingRights(boolean, boolean)
+     * @see File#of(int)
+     */
+    public void addCastlingRights(boolean white, boolean kingSide, int file) {
+        this.castlingRights.add(white, kingSide, file);
+    }
+
+    /** Sets the en passant file.
+     * <br>Defaults to -1
+     * @param enPassantFile the en passant file, or -1 if no en passant is possible
+     */
+    public void setEnPassantFile(int enPassantFile) {
+        this.enPassantFile = enPassantFile;
+    }
+
+    /** Sets the fifty move counter.
+     * <br>Defaults to 0
+     * @param fiftyMoveCounter the fifty move counter
+     */
+    public void setFiftyMoveCounter(int fiftyMoveCounter) {
+        this.fiftyMoveCounter = fiftyMoveCounter;
+    }
+
+    /** Builds a board based on the current state of the builder.
+     * @return the built board
+     * @throws IllegalArgumentException if current state is inconsistent, for example if a color has castle rights but no rook.
+     */
+    public Board build() {
+        final BitMaps bitmaps = new BitMaps(pieceList, whitePieces);
+        checkOneKing(bitmaps.whiteKing, true);
+        checkOneKing(bitmaps.blackKing, false);
+        checkEnPassant(bitmaps, enPassantFile);
+        final int rights = toRights(bitmaps);
+        
+        final Board board = new Board();
+        board.setVariant(variant);
+        board.setPieces(pieceList);
+        bitmaps.fill(board);
+        board.setWhite(whiteToMove);
+        board.getState().setEnPassantFile(enPassantFile);
+        board.getState().setRights(rights);
+        board.getState().setHalfMoveClock(fiftyMoveCounter);
+
+        board.getState().setKey(Key.generateKey(board));
+        board.getState().setPawnKey(Key.generatePawnKey(board));
+        board.getState().setNonPawnKeys(Key.generateNonPawnKeys(board));
+        return board;
+    }
+    
+    private void checkOneKing(long kings, boolean white) {
+        final int kingCount = Bits.count(kings);
+        if (kingCount != 1) {
+            throw new IllegalArgumentException(String.format("Expected one %s king, found %d.", Colour.label(white), kingCount));
+        }
+    }
+
+    private void checkEnPassant(BitMaps board, int enPassantFile) {
+        if (enPassantFile == -1) return;
+        // Check that en passant square corresponds to a pawn of the color that is NOT to move
+        final int rank = whiteToMove ? 4 : 3;
+        final int pawnSquare = Square.of(rank, enPassantFile);
+        final long colorPieces = whiteToMove ? board.blackPieces : board.whitePieces;
+        if (pieceList[pawnSquare] != PAWN || (Bits.of(pawnSquare) & colorPieces) == 0) {
+            throw new IllegalArgumentException(String.format("Illegal 'en passant' square. There's no %s pawn at %s!", Colour.label(!whiteToMove), Square.toNotation(pawnSquare)));
+        }
+    }
+ 
+    private int toRights(BitMaps board) {
+        int rights = Castling.empty();
+        if (castlingRights.isEmpty()) return rights;
+        rights = updateCastlingRight(board, rights, true, true);
+        rights = updateCastlingRight(board, rights, false, true);
+        rights = updateCastlingRight(board, rights, true, false);
+        rights = updateCastlingRight(board, rights, false, false);
+        if (variant==ChessVariant.CHESS960) {
+            // Check that files of kings are consistent if both colors can castle
+            if (castlingRights.colorHasCastling(true) && castlingRights.colorHasCastling(false) && File.of(board.kingSquare(true)) != File.of(board.kingSquare(false))) {
+                throw new IllegalArgumentException("Illegal castling rights, both kings are not on the same file");
+            }
+            // Check that files of rooks are consistent
+            if (castlingRights.bothColorsHasSideCastling(true) && File.of(Castling.getRook(rights, true, true)) != File.of(Castling.getRook(rights, true, false))) {
+                throw new IllegalArgumentException("Illegal castling rights, king side rooks are not on the same file");
+            }
+            if (castlingRights.bothColorsHasSideCastling(false) && File.of(Castling.getRook(rights, false, true)) != File.of(Castling.getRook(rights, false, false))) {
+                throw new IllegalArgumentException("Illegal castling rights, queen side rooks are not on the same file");
+            }
+        }
+        return rights;
+    }
+
+    private int updateCastlingRight(BitMaps bitmaps, int rights, boolean kingside, boolean white) {
+        final int right = castlingRights.get(white, kingside);
+        if (right == CastlingRights.NO_RIGHT) {
+            return rights;
+        } else if (right == CastlingRights.OUTER_MOST_ROOK) {
+            rights = Castling.setRook(rights, kingside, white, findRook(bitmaps, kingside, white));
+        } else {
+            final int rootSquare = Square.of(white ? 0:7, right);
+            rights = Castling.setRook(rights, kingside, white, rootSquare);
+        }
+        // Check if rook is at its starting position and if king is too
+        final long pieces = bitmaps.getPieces(white);
+        final int rookSquare;
+        if (variant==ChessVariant.CHESS960) {
+            rookSquare = Castling.getRook(rights, kingside, white);
+            // Check if king is at its starting position. In Chess960, the king can be at almost any position in its side of the board.
+            // The only constraint is there should be a rook at its side.
+            final int kingExpectedRank = white ? 0 : 7;
+            final int kingSquare = bitmaps.kingSquare(white);
+            if (Rank.of(kingSquare) != kingExpectedRank) {
+                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at its starting rank", Colour.label(white)));
+            }
+            // Check if king has moved (it has moved if it is at first or last file, or if it is not at the right side of the rook involved in the castling
+            final int kingFile = File.of(kingSquare);
+            final boolean effectiveKingSide = kingSquare<rookSquare;
+            if (kingFile==0 || kingFile==7 || kingside != effectiveKingSide) {
+                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at its starting file", Colour.label(white)));
+            }
+        } else {
+            // Check if king is at its starting position.
+            final int kingSquare = white ? 4 : 60;
+            if (pieceList[kingSquare] != KING || (pieces&Bits.of(kingSquare)) == 0) {
+                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at %s",Colour.label(white),Square.toNotation(kingSquare)));
+            }
+            rookSquare = Castling.rookFrom(kingside, white);
+        }
+        if (pieceList[rookSquare] != ROOK || (pieces&Bits.of(rookSquare)) == 0) {
+            throw new IllegalArgumentException(String.format("Illegal castling rights for %s, there's no rook at %s",Colour.label(white),Square.toNotation(rookSquare)));
+        }
+        return rights;
+    }
+
+    private int findRook(BitMaps bitMaps, boolean kingside, boolean white) {
+        final long firstRankRooks = getFirstRankRooks(bitMaps, white);
+        final List<Integer> squares = Arrays.stream(Bits.collect(firstRankRooks))
+                .boxed()
+                .sorted(Comparator.comparing(File::of))
+                .toList();
+        return kingside ? squares.get(squares.size() - 1) : squares.get(0);
+    }
+
+    private long getFirstRankRooks(BitMaps bitMaps, boolean white) {
+        final long firstRank = white ? Rank.FIRST : Rank.EIGHTH;
+        final long firstRankRooks = (white ? bitMaps.whiteRooks : bitMaps.blackRooks) & firstRank;
+        final long firstRankKings = (white ? bitMaps.whiteKing : bitMaps.blackKing) & firstRank;
+        if (Bits.count(firstRankRooks) == 0) {
+            throw new IllegalArgumentException(String.format("Illegal castling rights, there are no %s rooks on the first rank!", Colour.label(white)));
+        }
+        if (Bits.count(firstRankKings) == 0) {
+            throw new IllegalArgumentException(String.format("Illegal castling rights, there are no %s kings on the first rank!", Colour.label(white)));
+        }
+        return firstRankRooks;
+    }
+}

--- a/src/main/java/com/kelseyde/calvin/board/Castling.java
+++ b/src/main/java/com/kelseyde/calvin/board/Castling.java
@@ -1,10 +1,15 @@
 package com.kelseyde.calvin.board;
 
 /**
- * Utility class to handle castling rights. Especially important for (D)FRC, where the starting positions of the rooks
+ * Utility class to handle castling rights.
+ * <br>Especially important for <a href="https://en.wikipedia.org/wiki/Chess960/">Fisher random chess</a>, where the starting positions of the rooks
  * and king can vary, and the logic for handling castle moves is more complex.
  */
 public class Castling {
+    
+    private Castling() {
+        super();
+    }
 
     // For standard chess we can use some hardcoded shortcut values to simplify the logic
     public static class Standard {
@@ -60,7 +65,11 @@ public class Castling {
 
     public static int kingTo(boolean kingside, boolean white) {
         // Castling destination for king
-        return white ? (kingside ? 6 : 2) : (kingside ? 62 : 58);
+        if (kingside) {
+            return white ? 6 : 62;
+        } else {
+            return white ? 2 : 58;
+        }
     }
 
     public static boolean isKingside(int from, int to) {

--- a/src/main/java/com/kelseyde/calvin/board/Colour.java
+++ b/src/main/java/com/kelseyde/calvin/board/Colour.java
@@ -9,4 +9,8 @@ public class Colour {
         return white ? WHITE : BLACK;
     }
 
+    public static String label(boolean white) {
+        return white ? "white" : "black";
+    }
+
 }

--- a/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
+++ b/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
@@ -197,7 +197,7 @@ public class FEN {
     /**
      * Converts a Board to a Forsyth-Edwards Notation string
      * @param board the Board
-     * @return the Forsyth-Edwards Notation string
+     * @return the Forsyth-Edwards Notation string (if the board is a <a href="https://en.wikipedia.org/wiki/Chess960">chess960</a> board, the castling rights are encoded according to the <a href="https://www.chessprogramming.org/Forsyth-Edwards_Notation#Shredder-FEN">Shredder FEN</a> format)
      */
     public static String toFEN(Board board) {
         try {

--- a/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
+++ b/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
@@ -11,11 +11,16 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 public class FEN {
+    private FEN() {
+        super();
+    }
 
     public static final String STARTPOS = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
     public static Board toBoard(String fen) {
-
+            if (fen==null) {
+                throw new IllegalArgumentException();
+            }
             String[] parts = fen.split(" ");
             String[] files = parts[0].split("/");
 

--- a/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
+++ b/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
@@ -1,10 +1,12 @@
 package com.kelseyde.calvin.utils.notation;
 
+import static com.kelseyde.calvin.board.Piece.*;
+
 import com.kelseyde.calvin.board.*;
 
 import java.util.Arrays;
+import java.util.BitSet;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -25,29 +27,23 @@ public class FEN {
 
     private static final class PiecesParser {
         private static final String EMPTY_CELL = "x";
-        private long whitePawns = 0L;
-        private long whiteKnights = 0L;
-        private long whiteBishops = 0L;
-        private long whiteRooks = 0L;
-        private long whiteQueens = 0L;
-        private long whiteKing = 0L;
-        private long blackPawns = 0L;
-        private long blackKnights = 0L;
-        private long blackBishops = 0L;
-        private long blackRooks = 0L;
-        private long blackQueens = 0L;
-        private long blackKing = 0L;
 
-        PiecesParser (String[] files) {
-            List<List<String>> rankFileHash = Arrays.stream(files)
+        /** Populates a builder with the pieces.
+         * @param builder The builder to populate 
+         * @param pieces The FEN pieces parts ranks
+         * @return
+         */
+        static int[] parsePieces(BoardBuilder builder, String pieces) {
+            final List<List<String>> rankFileHash = Arrays.stream(pieces.split("/"))
                     .map(file -> Arrays.stream(file.split(""))
-                            .flatMap(this::parseSquare)
+                            .flatMap(PiecesParser::parseSquare)
                             .toList())
                     .collect(Collectors.toList());
             if (rankFileHash.size() != 8) {
                 throw new IllegalArgumentException("Illegal FEN: rank count is not 8!");
             }
             Collections.reverse(rankFileHash);
+            final int[] kingsPosition = {-1, -1};
             for (int rankIndex = 0; rankIndex < rankFileHash.size(); rankIndex++) {
                 final List<String> rank = rankFileHash.get(rankIndex);
                 if (rank.size() != 8) {
@@ -55,21 +51,23 @@ public class FEN {
                 }
                 for (int fileIndex = 0; fileIndex < rank.size(); fileIndex++) {
                     final int square = Square.of(rankIndex, fileIndex);
-                    final String squareValue = rank.get(fileIndex);
-                    final long squareBB = Bits.of(square);
+                    String squareValue = rank.get(fileIndex);
+                    final boolean white = Character.isUpperCase(squareValue.charAt(0));
+                    if (white) squareValue = squareValue.toLowerCase();
                     switch (squareValue) {
-                        case "P" -> whitePawns |= squareBB;
-                        case "N" -> whiteKnights |= squareBB;
-                        case "B" -> whiteBishops |= squareBB;
-                        case "R" -> whiteRooks |= squareBB;
-                        case "Q" -> whiteQueens |= squareBB;
-                        case "K" -> whiteKing |= squareBB;
-                        case "p" -> blackPawns |= squareBB;
-                        case "n" -> blackKnights |= squareBB;
-                        case "b" -> blackBishops |= squareBB;
-                        case "r" -> blackRooks |= squareBB;
-                        case "q" -> blackQueens |= squareBB;
-                        case "k" -> blackKing |= squareBB;
+                        case "p" -> builder.addPiece(square, PAWN, white);
+                        case "n" -> builder.addPiece(square, KNIGHT, white);
+                        case "b" -> builder.addPiece(square, BISHOP, white);
+                        case "r" -> builder.addPiece(square, ROOK, white);
+                        case "q" -> builder.addPiece(square, QUEEN, white);
+                        case "k" -> {
+                            builder.addPiece(square, KING, white);
+                            if (white) {
+                                kingsPosition[0] = square;
+                            } else {
+                                kingsPosition[1] = square;
+                            }
+                        }
                         case EMPTY_CELL -> {
                             // No piece, do nothing
                         }
@@ -77,11 +75,10 @@ public class FEN {
                     }
                 }
             }
-            checkOneKing(true);
-            checkOneKing(false);
+            return kingsPosition;
         }
         
-        private Stream<String> parseSquare(String square) {
+        private static Stream<String> parseSquare(String square) {
             if (square.length() != 1) {
                 // A rank was empty
                 throw new IllegalArgumentException("Illegal FEN a rank can't be empty!");
@@ -96,41 +93,64 @@ public class FEN {
             return IntStream.range(0, Integer.parseInt(square)).mapToObj(i -> EMPTY_CELL);
         }
 
-        private void illegalPiece(String piece) {
-            throw new IllegalArgumentException("Illegal FEN: " + piece + " is not a valid piece!");
+        private static void illegalPiece(String piece) {
+            throw new IllegalArgumentException(String.format("Illegal FEN: '%s' is not a valid piece!", piece));
         }
+    }
+    
+    private static class CastlingParser {
+        private final BitSet hasCastling;
+        private final BoardBuilder builder;
 
-        private void checkOneKing(boolean white) {
-            final long king = white ? whiteKing : blackKing;
-            if (Bits.count(king) != 1) {
-                throw new IllegalArgumentException(String.format("Illegal FEN: Expected one king, found %d.", Bits.count(king)));
+        private CastlingParser(BoardBuilder builder) {
+            hasCastling = new BitSet();
+            this.builder = builder;
+        }
+        private void set(boolean white, boolean kingside, Integer file) {
+            int index = Colour.index(white);
+            if (!kingside) {
+                index += 2;
+            }
+            if (hasCastling.get(index)) {
+                throw new IllegalArgumentException(String.format("Illegal FEN: %s %s side castling rights are defined multiple times!", Colour.label(white), kingside ? "king":"queen"));
+            }
+            hasCastling.set(index, white);
+            if (file != null) {
+                builder.addCastlingRights(white, kingside, file);
+            } else {
+                builder.addCastlingRights(white, kingside);
             }
         }
 
-        private void fillBoard(Board board) {
-            board.setPawns(whitePawns | blackPawns);
-            board.setKnights(whiteKnights | blackKnights);
-            board.setBishops(whiteBishops | blackBishops);
-            board.setRooks(whiteRooks | blackRooks);
-            board.setQueens(whiteQueens | blackQueens);
-            board.setKings(whiteKing | blackKing);
-            board.setWhitePieces(whitePawns | whiteKnights | whiteBishops | whiteRooks | whiteQueens | whiteKing);
-            board.setBlackPieces(blackPawns | blackKnights | blackBishops | blackRooks | blackQueens | blackKing);
-            board.setPieces(calculatePieceList(board));
-        }
-        
-        private Piece[] calculatePieceList(Board board) {
-            final Piece[] pieceList = new Piece[Square.COUNT];
-            for (int square = 0; square < Square.COUNT; square++) {
-                final long squareMask = Bits.of(square);
-                if ((squareMask & board.getPawns()) != 0)           pieceList[square] = Piece.PAWN;
-                else if ((squareMask & board.getKnights()) != 0)    pieceList[square] = Piece.KNIGHT;
-                else if ((squareMask & board.getBishops()) != 0)    pieceList[square] = Piece.BISHOP;
-                else if ((squareMask & board.getRooks()) != 0)      pieceList[square] = Piece.ROOK;
-                else if ((squareMask & board.getQueens()) != 0)     pieceList[square] = Piece.QUEEN;
-                else if ((squareMask & board.getKings()) != 0)      pieceList[square] = Piece.KING;
+        private void parseCastlingRights(String castlingRights, BoardBuilder builder, int whiteKing, int blackKing) {
+            if (castlingRights.length() > 4) {
+                throw new IllegalArgumentException("Invalid castling rights! " + castlingRights);
             }
-            return pieceList;
+            for (int i = 0; i < castlingRights.length(); i++) {
+                char right = castlingRights.charAt(i);
+                switch (right) {
+                    case 'K' -> set(true, true, null);
+                    case 'Q' -> set(true, false, null);
+                    case 'k' -> set(false, true, null);
+                    case 'q' -> set(false, false, null);
+                    case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H' -> {
+                        // Shredder FEN: White rooks on specified files
+                        int file = File.fromNotation(right);
+                        int kingFile = File.of(whiteKing);
+                        set(true, file > kingFile, file);
+                    }
+                    case 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' -> {
+                        // Shredder FEN: Black rooks on specified files
+                        int file = File.fromNotation(Character.toUpperCase(right));
+                        int kingFile = File.of(blackKing);
+                        set(false, file > kingFile, file);
+                    }
+                    case '-' -> {
+                        // No castling rights, nothing to do
+                    }
+                    default -> throw new IllegalArgumentException("Invalid castling right! " + right);
+                }
+            }
         }
     }
 
@@ -143,7 +163,7 @@ public class FEN {
      * @throws IllegalArgumentException if the FEN string is not valid
      */
     public static Board toBoard(String fen) {
-            return toBoard(fen, ChessVariant.STANDARD);
+        return toBoard(fen, ChessVariant.STANDARD);
     }
 
     /** 
@@ -156,106 +176,22 @@ public class FEN {
      * @throws IllegalArgumentException if the FEN string is not valid
      */
     public static Board toBoard(String fen, ChessVariant variant) {
-            if (fen==null || variant==null) {
-                throw new IllegalArgumentException();
-            }
-            final String[] parts = fen.split(" ");
-            final PiecesParser piecesParser = new PiecesParser(parts[0].split("/"));
-
-            final boolean whiteToMove = parseSideToMove(parts[1]);
-            final int castlingRights = parseCastlingRights(parts[2], piecesParser.whiteRooks, piecesParser.blackRooks,
-                    Bits.next(piecesParser.whiteKing), Bits.next(piecesParser.blackKing));
-            final int enPassantFile = parseEnPassantFile(parts[3], whiteToMove);
-            final int fiftyMoveCounter = parts.length > 4 ? parseFiftyMoveCounter(parts[4]) : 0;
-            // This implementation does not require the full move counter (parts[5]).
-
-            final Board board = new Board();
-            board.setVariant(variant);
-            piecesParser.fillBoard(board);
-            board.setWhite(whiteToMove);
-            board.getState().setHalfMoveClock(fiftyMoveCounter);
-            checkEnPassant(board, enPassantFile);
-            checkCastlingRights(board, castlingRights);
-            board.getState().setRights(castlingRights);
-            board.getState().setEnPassantFile(enPassantFile);
-
-            board.getState().setKey(Key.generateKey(board));
-            board.getState().setPawnKey(Key.generatePawnKey(board));
-            board.getState().setNonPawnKeys(Key.generateNonPawnKeys(board));
-
-            return board;
-    }
-
-    private static void checkEnPassant(Board board, int enPassantFile) {
-        if (enPassantFile == -1) return;
-        // Check that en passant square corresponds to a pawn of the color that is NOT to move
-        final int rank = board.isWhite() ? 4 : 3;
-        final int pawnSquare = Square.of(rank, enPassantFile);
-        final long colorPieces = board.isWhite() ? board.getBlackPieces() : board.getWhitePieces();
-        if (board.pieceAt(pawnSquare) != Piece.PAWN || (Bits.of(pawnSquare) & colorPieces) == 0) {
-            throw new IllegalArgumentException(String.format("Illegal 'en passant' square. There's no %s pawn at %s!", colorLabel(!board.isWhite()), Square.toNotation(pawnSquare)));
+        if (fen==null || fen.trim().isEmpty()) {
+            throw new IllegalArgumentException();
         }
-    }
-    
-    private static void checkCastlingRights(Board board, int castlingRights) {
-        if (castlingRights == 0) return;
-        final boolean whiteKingSide = checkCastlingRight(board, castlingRights, true, true);
-        final boolean whiteQueenSide = checkCastlingRight(board, castlingRights, false, true);
-        final boolean blackKingSide = checkCastlingRight(board, castlingRights, true, false);
-        final boolean blackQueenSide = checkCastlingRight(board, castlingRights, false, false);
-        if (board.variant()==ChessVariant.CHESS960) {
-            // Check that files of kings are consistent if both colors can castle
-            if ((whiteKingSide || whiteQueenSide) && (blackKingSide || blackQueenSide) && File.of(board.kingSquare(true)) != File.of(board.kingSquare(false))) {
-                throw new IllegalArgumentException("Illegal castling rights, both kings are not on the same file");
-            }
-            // Check that files of rooks are consistent
-            if (whiteKingSide && blackKingSide && File.of(Castling.getRook(castlingRights, true, true)) != File.of(Castling.getRook(castlingRights, true, false))) {
-                throw new IllegalArgumentException("Illegal castling rights, king side rooks are not on the same file");
-            }
-            if (whiteQueenSide && blackQueenSide && File.of(Castling.getRook(castlingRights, false, true)) != File.of(Castling.getRook(castlingRights, false, false))) {
-                throw new IllegalArgumentException("Illegal castling rights, queen side rooks are not on the same file");
-            }
-        }
-    }
+        final BoardBuilder builder = new BoardBuilder(variant);
+        final String[] parts = fen.split(" ");
+        final int[] kingPositions = PiecesParser.parsePieces(builder, parts[0]);
 
-    private static boolean checkCastlingRight(Board board, int castlingRights, boolean kingside, boolean white) {
-        final boolean allowed = kingside ? Castling.kingsideAllowed(castlingRights, white) : Castling.queensideAllowed(castlingRights, white);
-        if (!allowed) {
-            return false;
-        }
-        // Check if rook is at its starting position and if king is too
-        final long pieces = board.getPieces(white);
-        final int rookSquare;
-        if (board.variant()==ChessVariant.CHESS960) {
-            rookSquare = Castling.getRook(castlingRights, kingside, white);
-            // Check if king is at its starting position. In Chess960, the king can be at almost any position in its side of the board.
-            // The only constraint is there should be a rook at its side.
-            final int kingExpectedRank = white ? 0 : 7;
-            final int kingSquare = board.kingSquare(white);
-            if (Rank.of(kingSquare) != kingExpectedRank) {
-                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at its starting rank", colorLabel(white)));
-            }
-            // Check if king has moved (it has moved if it is at first or last file, or if it is not at the right side of the rook involved in the castling
-            final int kingFile = File.of(kingSquare);
-            final boolean effectiveKingSide = kingSquare<rookSquare;
-            if (kingFile==0 || kingFile==7 || kingside != effectiveKingSide) {
-                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at its starting file", colorLabel(white)));
-            }
-        } else {
-            final int kingSquare = white ? 4 : 60;
-            if (board.pieceAt(kingSquare) != Piece.KING || (pieces&Bits.of(kingSquare)) == 0) {
-                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at %s",colorLabel(white),Square.toNotation(kingSquare)));
-            }
-            rookSquare = Castling.rookFrom(kingside, white);
-        }
-        if (board.pieceAt(rookSquare) != Piece.ROOK || (pieces&Bits.of(rookSquare)) == 0) {
-            throw new IllegalArgumentException(String.format("Illegal castling rights for %s, there's no rook at %s",colorLabel(white),Square.toNotation(rookSquare)));
-        }
-        return true;
-    }
+        final boolean whiteToMove = parseSideToMove(parts[1]);
+        builder.setWhiteToMove(whiteToMove);
+        
+        new CastlingParser(builder).parseCastlingRights(parts[2], builder, kingPositions[0], kingPositions[1]);
+        builder.setEnPassantFile(parseEnPassantFile(parts[3], whiteToMove));
+        builder.setFiftyMoveCounter(parts.length > 4 ? parseFiftyMoveCounter(parts[4]) : 0);
+        // This implementation does not require the full move counter (parts[5]).
 
-    private static String colorLabel(boolean white) {
-        return white ? "white" : "black";
+        return builder.build();
     }
 
     /**
@@ -327,55 +263,6 @@ public class FEN {
         return sideToMove ? "w" : "b";
     }
 
-    private static int parseCastlingRights(String castlingRights, long whiteRooks, long blackRooks, int whiteKing, int blackKing) {
-        if (castlingRights.length() > 4) {
-            throw new IllegalArgumentException("Invalid castling rights! " + castlingRights);
-        }
-        int rights = Castling.empty();
-        for (int i = 0; i < castlingRights.length(); i++) {
-            char right = castlingRights.charAt(i);
-            switch (right) {
-                case 'K' -> rights = updateCastlingRights(rights, true, true, findRook(whiteRooks, true, true));
-                case 'Q' -> rights = updateCastlingRights(rights, false, true, findRook(whiteRooks, false, true));
-                case 'k' -> rights = updateCastlingRights(rights, true, false, findRook(blackRooks, true, false));
-                case 'q' -> rights = updateCastlingRights(rights, false, false, findRook(blackRooks, false, false));
-                case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H' -> {
-                    // Shredder FEN: White rooks on specified files
-                    int file = File.fromNotation(right);
-                    int kingFile = File.of(whiteKing);
-                    if (file < kingFile) {
-                        rights = Castling.setRook(rights, false, true, Square.of(0, file)); // Queenside
-                    } else {
-                        rights = Castling.setRook(rights, true, true, Square.of(0, file));  // Kingside
-                    }
-                }
-                case 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h' -> {
-                    // Shredder FEN: Black rooks on specified files
-                    int file = File.fromNotation(Character.toUpperCase(right));
-                    int kingFile = File.of(blackKing);
-                    if (file < kingFile) {
-                        rights = Castling.setRook(rights, false, false, Square.of(7, file)); // Queenside
-                    } else {
-                        rights = Castling.setRook(rights, true, false, Square.of(7, file));  // Kingside
-                    }
-                }
-                case '-' -> {
-                    // No castling rights, so return empty rights directly
-                    return Castling.empty();
-                }
-                default -> throw new IllegalArgumentException("Invalid castling right! " + right);
-            }
-        }
-        return rights;
-    }
-    
-    private static int updateCastlingRights(int rights, boolean kingside, boolean white, int square) {
-        if ((kingside && Castling.kingsideAllowed(rights, white)) || (!kingside && Castling.queensideAllowed(rights, white))) {
-            throw new IllegalArgumentException(String.format("Invalid castling for %s, there are two %s side castlings defined", colorLabel(white), kingside ? "king":"queen"));
-        }
-        return Castling.setRook(rights, kingside, white, square);
-    }
-
     private static String toCastlingRights(Board board, int rights) {
         if (rights == Castling.empty()) {
             return "-";
@@ -442,26 +329,5 @@ public class FEN {
 
     private static String toFullMoveCounter(int ply) {
         return Integer.toString(1 + (ply / 2));
-    }
-
-    private static int findRook(long rooks, boolean kingside, boolean white) {
-
-        long firstRank = white ? Rank.FIRST : Rank.EIGHTH;
-        long firstRankRooks = rooks & firstRank;
-
-        if (Bits.count(firstRankRooks) == 0) {
-            throw new IllegalArgumentException("Illegal FEN: castling rights with no rooks on the first rank!");
-        }
-
-        if (Bits.count(firstRankRooks) == 1) {
-            return Bits.next(firstRankRooks);
-        }
-
-        List<Integer> squares = Arrays.stream(Bits.collect(firstRankRooks))
-                .boxed()
-                .sorted(Comparator.comparing(File::of))
-                .toList();
-
-        return kingside ? squares.get(squares.size() - 1) : squares.get(0);
     }
 }

--- a/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
+++ b/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
@@ -77,6 +77,8 @@ public class FEN {
                     }
                 }
             }
+            checkOneKing(true);
+            checkOneKing(false);
         }
         
         private Stream<String> parseSquare(String square) {
@@ -96,6 +98,13 @@ public class FEN {
 
         private void illegalPiece(String piece) {
             throw new IllegalArgumentException("Illegal FEN: " + piece + " is not a valid piece!");
+        }
+
+        private void checkOneKing(boolean white) {
+            final long king = white ? whiteKing : blackKing;
+            if (Bits.count(king) != 1) {
+                throw new IllegalArgumentException(String.format("Illegal FEN: Expected one king, found %d.", Bits.count(king)));
+            }
         }
 
         private void fillBoard(Board board) {
@@ -176,7 +185,7 @@ public class FEN {
 
             return board;
     }
-    
+
     private static void checkEnPassant(Board board, int enPassantFile) {
         if (enPassantFile == -1) return;
         // Check that en passant square corresponds to a pawn of the color that is NOT to move
@@ -196,14 +205,14 @@ public class FEN {
         final boolean blackQueenSide = checkCastlingRight(board, castlingRights, false, false);
         if (board.variant()==ChessVariant.CHESS960) {
             // Check that files of kings are consistent if both colors can castle
-            if ((whiteKingSide || whiteQueenSide) && (blackKingSide || blackQueenSide) && board.kingSquare(true)%8 != board.kingSquare(false)%8) {
+            if ((whiteKingSide || whiteQueenSide) && (blackKingSide || blackQueenSide) && File.of(board.kingSquare(true)) != File.of(board.kingSquare(false))) {
                 throw new IllegalArgumentException("Illegal castling rights, both kings are not on the same file");
             }
             // Check that files of rooks are consistent
-            if (whiteKingSide && blackKingSide && Castling.getRook(castlingRights, true, true)%8 != Castling.getRook(castlingRights, true, false)%8) {
+            if (whiteKingSide && blackKingSide && File.of(Castling.getRook(castlingRights, true, true)) != File.of(Castling.getRook(castlingRights, true, false))) {
                 throw new IllegalArgumentException("Illegal castling rights, king side rooks are not on the same file");
             }
-            if (whiteQueenSide && blackQueenSide && Castling.getRook(castlingRights, false, true)%8 != Castling.getRook(castlingRights, false, false)%8) {
+            if (whiteQueenSide && blackQueenSide && File.of(Castling.getRook(castlingRights, false, true)) != File.of(Castling.getRook(castlingRights, false, false))) {
                 throw new IllegalArgumentException("Illegal castling rights, queen side rooks are not on the same file");
             }
         }
@@ -223,17 +232,17 @@ public class FEN {
             // The only constraint is there should be a rook at its side.
             final int kingExpectedRank = white ? 0 : 7;
             final int kingSquare = board.kingSquare(white);
-            if (kingSquare/8 != kingExpectedRank) {
+            if (Rank.of(kingSquare) != kingExpectedRank) {
                 throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at it starting rank", colorLabel(white)));
             }
             // Check if king has moved (it has moved if it is at first or last file, or if it is not at the right side of the rook involved in the castling
-            final int kingFile = kingSquare % 8;
+            final int kingFile = File.of(kingSquare);
             final boolean effectiveKingSide = kingSquare<rookSquare;
             if (kingFile==0 || kingFile==7 || kingside != effectiveKingSide) {
                 throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at it starting file", colorLabel(white)));
             }
         } else {
-            final int kingSquare = white ?4 : 60;
+            final int kingSquare = white ? 4 : 60;
             if (board.pieceAt(kingSquare) != Piece.KING || (pieces&Bits.of(kingSquare)) == 0) {
                 throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at %s",colorLabel(white),Square.toNotation(kingSquare)));
             }
@@ -326,10 +335,10 @@ public class FEN {
         for (int i = 0; i < castlingRights.length(); i++) {
             char right = castlingRights.charAt(i);
             switch (right) {
-                case 'K' -> rights = Castling.setRook(rights, true, true, findRook(whiteRooks, true, true));
-                case 'Q' -> rights = Castling.setRook(rights, false, true, findRook(whiteRooks, false, true));
-                case 'k' -> rights = Castling.setRook(rights, true, false, findRook(blackRooks, true, false));
-                case 'q' -> rights = Castling.setRook(rights, false, false, findRook(blackRooks, false, false));
+                case 'K' -> rights = updateCastlingRights(rights, true, true, findRook(whiteRooks, true, true));
+                case 'Q' -> rights = updateCastlingRights(rights, false, true, findRook(whiteRooks, false, true));
+                case 'k' -> rights = updateCastlingRights(rights, true, false, findRook(blackRooks, true, false));
+                case 'q' -> rights = updateCastlingRights(rights, false, false, findRook(blackRooks, false, false));
                 case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H' -> {
                     // Shredder FEN: White rooks on specified files
                     int file = File.fromNotation(right);
@@ -358,6 +367,13 @@ public class FEN {
             }
         }
         return rights;
+    }
+    
+    private static int updateCastlingRights(int rights, boolean kingside, boolean white, int square) {
+        if ((kingside && Castling.kingsideAllowed(rights, white)) || (!kingside && Castling.queensideAllowed(rights, white))) {
+            throw new IllegalArgumentException(String.format("Invalid castling for %s, there are two %s side castlings defined", colorLabel(white), kingside ? "king":"queen"));
+        }
+        return Castling.setRook(rights, kingside, white, square);
     }
 
     private static String toCastlingRights(Board board, int rights) {
@@ -447,8 +463,5 @@ public class FEN {
                 .toList();
 
         return kingside ? squares.get(squares.size() - 1) : squares.get(0);
-
     }
-
-
 }

--- a/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
+++ b/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
@@ -164,7 +164,7 @@ public class FEN {
 
             final boolean whiteToMove = parseSideToMove(parts[1]);
             final int castlingRights = parseCastlingRights(parts[2], piecesParser.whiteRooks, piecesParser.blackRooks,
-                    Bits.next(piecesParser.whiteKing), Bits.next(piecesParser.blackKing), variant==ChessVariant.CHESS960);
+                    Bits.next(piecesParser.whiteKing), Bits.next(piecesParser.blackKing));
             final int enPassantFile = parseEnPassantFile(parts[3], whiteToMove);
             final int fiftyMoveCounter = parts.length > 4 ? parseFiftyMoveCounter(parts[4]) : 0;
             // This implementation does not require the full move counter (parts[5]).
@@ -233,13 +233,13 @@ public class FEN {
             final int kingExpectedRank = white ? 0 : 7;
             final int kingSquare = board.kingSquare(white);
             if (Rank.of(kingSquare) != kingExpectedRank) {
-                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at it starting rank", colorLabel(white)));
+                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at its starting rank", colorLabel(white)));
             }
             // Check if king has moved (it has moved if it is at first or last file, or if it is not at the right side of the rook involved in the castling
             final int kingFile = File.of(kingSquare);
             final boolean effectiveKingSide = kingSquare<rookSquare;
             if (kingFile==0 || kingFile==7 || kingside != effectiveKingSide) {
-                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at it starting file", colorLabel(white)));
+                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at its starting file", colorLabel(white)));
             }
         } else {
             final int kingSquare = white ? 4 : 60;
@@ -327,7 +327,7 @@ public class FEN {
         return sideToMove ? "w" : "b";
     }
 
-    private static int parseCastlingRights(String castlingRights, long whiteRooks, long blackRooks, int whiteKing, int blackKing, boolean isChess960Supported) {
+    private static int parseCastlingRights(String castlingRights, long whiteRooks, long blackRooks, int whiteKing, int blackKing) {
         if (castlingRights.length() > 4) {
             throw new IllegalArgumentException("Invalid castling rights! " + castlingRights);
         }

--- a/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
+++ b/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
@@ -126,7 +126,7 @@ public class FEN {
     }
 
     /** 
-     * Converts a Forsyth-Edwards Notation string to a Board
+     * Converts a Forsyth-Edwards Notation string to a standard board
      * @param fen the Forsyth-Edwards Notation string. Both half move clock and move counter are optional.
      * <br>If half move clock is not provided, it is set to 0.
      * <br>Move counter is ignored, due to a limitation of Board class that does not support it when played moves are not provided.
@@ -134,7 +134,20 @@ public class FEN {
      * @throws IllegalArgumentException if the FEN string is not valid
      */
     public static Board toBoard(String fen) {
-            if (fen==null) {
+            return toBoard(fen, ChessVariant.STANDARD);
+    }
+
+    /** 
+     * Converts a Forsyth-Edwards Notation string to a Board
+     * @param fen the Forsyth-Edwards Notation string. Both half move clock and move counter are optional.
+     * <br>If half move clock is not provided, it is set to 0.
+     * <br>Move counter is ignored, due to a limitation of Board class that does not support it when played moves are not provided.
+     * @param variant the ChessVariant to use
+     * @return the Board
+     * @throws IllegalArgumentException if the FEN string is not valid
+     */
+    public static Board toBoard(String fen, ChessVariant variant) {
+            if (fen==null || variant==null) {
                 throw new IllegalArgumentException();
             }
             final String[] parts = fen.split(" ");
@@ -147,16 +160,80 @@ public class FEN {
             // This implementation does not require the full move counter (parts[5]).
 
             final Board board = new Board();
+            board.setVariant(variant);
             piecesParser.fillBoard(board);
-            board.setWhite(whiteToMove);
+            checkCastlingRights(board, castlingRights);
             board.getState().setRights(castlingRights);
             board.getState().setEnPassantFile(enPassantFile);
             board.getState().setHalfMoveClock(fiftyMoveCounter);
+            board.setWhite(whiteToMove);
+
             board.getState().setKey(Key.generateKey(board));
             board.getState().setPawnKey(Key.generatePawnKey(board));
             board.getState().setNonPawnKeys(Key.generateNonPawnKeys(board));
 
             return board;
+    }
+    
+    private static void checkCastlingRights(Board board, int castlingRights) {
+        if (castlingRights == 0) return;
+        final boolean whiteKingSide = checkCastlingRight(board, castlingRights, true, true);
+        final boolean whiteQueenSide = checkCastlingRight(board, castlingRights, false, true);
+        final boolean blackKingSide = checkCastlingRight(board, castlingRights, true, false);
+        final boolean blackQueenSide = checkCastlingRight(board, castlingRights, false, false);
+        if (board.variant()==ChessVariant.CHESS960) {
+            // Check that files of kings are consistent if both colors can castle
+            if ((whiteKingSide || whiteQueenSide) && (blackKingSide || blackQueenSide) && board.kingSquare(true)%8 != board.kingSquare(false)%8) {
+                throw new IllegalArgumentException("Illegal castling rights, both kings are not on the same file");
+            }
+            // Check that files of rooks are consistent
+            if (whiteKingSide && blackKingSide && Castling.getRook(castlingRights, true, true)%8 != Castling.getRook(castlingRights, true, false)%8) {
+                throw new IllegalArgumentException("Illegal castling rights, king side rooks are not on the same file");
+            }
+            if (whiteQueenSide && blackQueenSide && Castling.getRook(castlingRights, false, true)%8 != Castling.getRook(castlingRights, false, false)%8) {
+                throw new IllegalArgumentException("Illegal castling rights, queen side rooks are not on the same file");
+            }
+        }
+    }
+
+    private static boolean checkCastlingRight(Board board, int castlingRights, boolean kingside, boolean white) {
+        final boolean allowed = kingside ? Castling.kingsideAllowed(castlingRights, white) : Castling.queensideAllowed(castlingRights, white);
+        if (!allowed) {
+            return false;
+        }
+        // Check if rook is at its starting position and if king is too
+        final long pieces = board.getPieces(white);
+        final int rookSquare;
+        if (board.variant()==ChessVariant.CHESS960) {
+            rookSquare = Castling.getRook(castlingRights, kingside, white);
+            // Check if king is at its starting position. In Chess960, the king can be at almost any position in its side of the board.
+            // The only constraint is there should be a rook at its side.
+            final int kingExpectedRank = white ? 0 : 7;
+            final int kingSquare = board.kingSquare(white);
+            if (kingSquare/8 != kingExpectedRank) {
+                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at it starting rank", colorLabel(white)));
+            }
+            // Check if king has moved (it has moved if it is at first or last file, or if it is not at the right side of the rook involved in the castling
+            final int kingFile = kingSquare % 8;
+            final boolean effectiveKingSide = kingSquare<rookSquare;
+            if (kingFile==0 || kingFile==7 || kingside != effectiveKingSide) {
+                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at it starting file", colorLabel(white)));
+            }
+        } else {
+            final int kingSquare = white ?4 : 60;
+            if (board.pieceAt(kingSquare) != Piece.KING || (pieces&Bits.of(kingSquare)) == 0) {
+                throw new IllegalArgumentException(String.format("Illegal castling rights for %s, king is not at %s",colorLabel(white),Square.toNotation(kingSquare)));
+            }
+            rookSquare = Castling.rookFrom(kingside, white);
+        }
+        if (board.pieceAt(rookSquare) != Piece.ROOK || (pieces&Bits.of(rookSquare)) == 0) {
+            throw new IllegalArgumentException(String.format("Illegal castling rights for %s, there's no rook at %s",colorLabel(white),Square.toNotation(rookSquare)));
+        }
+        return true;
+    }
+
+    private static String colorLabel(boolean white) {
+        return white ? "white" : "black";
     }
 
     /**
@@ -237,8 +314,8 @@ public class FEN {
             char right = castlingRights.charAt(i);
             switch (right) {
                 case 'K' -> rights = Castling.setRook(rights, true, true, findRook(whiteRooks, true, true));
-                case 'Q' -> rights = Castling.setRook(rights, false, true, findRook(whiteRooks, true, false));
-                case 'k' -> rights = Castling.setRook(rights, true, false, findRook(blackRooks, false, true));
+                case 'Q' -> rights = Castling.setRook(rights, false, true, findRook(whiteRooks, false, true));
+                case 'k' -> rights = Castling.setRook(rights, true, false, findRook(blackRooks, true, false));
                 case 'q' -> rights = Castling.setRook(rights, false, false, findRook(blackRooks, false, false));
                 case 'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H' -> {
                     // Shredder FEN: White rooks on specified files
@@ -334,7 +411,7 @@ public class FEN {
         return Integer.toString(1 + (ply / 2));
     }
 
-    private static int findRook(long rooks, boolean white, boolean kingside) {
+    private static int findRook(long rooks, boolean kingside, boolean white) {
 
         long firstRank = white ? Rank.FIRST : Rank.EIGHTH;
         long firstRankRooks = rooks & firstRank;

--- a/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
+++ b/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
@@ -24,7 +24,7 @@ public class FEN {
     public static final String STARTPOS = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
     private static final class PiecesParser {
-        private static final String noPieceCode = "x";
+        private static final String EMPTY_CELL = "x";
         private long whitePawns = 0L;
         private long whiteKnights = 0L;
         private long whiteBishops = 0L;
@@ -70,7 +70,7 @@ public class FEN {
                         case "r" -> blackRooks |= squareBB;
                         case "q" -> blackQueens |= squareBB;
                         case "k" -> blackKing |= squareBB;
-                        case noPieceCode -> {
+                        case EMPTY_CELL -> {
                             // No piece, do nothing
                         }
                         default -> illegalPiece(squareValue);
@@ -85,13 +85,13 @@ public class FEN {
                 throw new IllegalArgumentException("Illegal FEN a rank can't be empty!");
             }
             if (Character.isLetter(square.charAt(0))) {
-                if (noPieceCode.equals(square)) {
+                if (EMPTY_CELL.equals(square)) {
                     illegalPiece(square);
                 } else {
                     return Stream.of(square);
                 }
             }
-            return IntStream.range(0, Integer.parseInt(square)).mapToObj(i -> noPieceCode);
+            return IntStream.range(0, Integer.parseInt(square)).mapToObj(i -> EMPTY_CELL);
         }
 
         private void illegalPiece(String piece) {
@@ -154,25 +154,38 @@ public class FEN {
             final PiecesParser piecesParser = new PiecesParser(parts[0].split("/"));
 
             final boolean whiteToMove = parseSideToMove(parts[1]);
-            final int castlingRights = parseCastlingRights(parts[2], piecesParser.whiteRooks, piecesParser.blackRooks, Bits.next(piecesParser.whiteKing), Bits.next(piecesParser.blackKing));
-            final int enPassantFile = parseEnPassantFile(parts[3]);
+            final int castlingRights = parseCastlingRights(parts[2], piecesParser.whiteRooks, piecesParser.blackRooks,
+                    Bits.next(piecesParser.whiteKing), Bits.next(piecesParser.blackKing), variant==ChessVariant.CHESS960);
+            final int enPassantFile = parseEnPassantFile(parts[3], whiteToMove);
             final int fiftyMoveCounter = parts.length > 4 ? parseFiftyMoveCounter(parts[4]) : 0;
             // This implementation does not require the full move counter (parts[5]).
 
             final Board board = new Board();
             board.setVariant(variant);
             piecesParser.fillBoard(board);
+            board.setWhite(whiteToMove);
+            board.getState().setHalfMoveClock(fiftyMoveCounter);
+            checkEnPassant(board, enPassantFile);
             checkCastlingRights(board, castlingRights);
             board.getState().setRights(castlingRights);
             board.getState().setEnPassantFile(enPassantFile);
-            board.getState().setHalfMoveClock(fiftyMoveCounter);
-            board.setWhite(whiteToMove);
 
             board.getState().setKey(Key.generateKey(board));
             board.getState().setPawnKey(Key.generatePawnKey(board));
             board.getState().setNonPawnKeys(Key.generateNonPawnKeys(board));
 
             return board;
+    }
+    
+    private static void checkEnPassant(Board board, int enPassantFile) {
+        if (enPassantFile == -1) return;
+        // Check that en passant square corresponds to a pawn of the color that is NOT to move
+        final int rank = board.isWhite() ? 4 : 3;
+        final int pawnSquare = Square.of(rank, enPassantFile);
+        final long colorPieces = board.isWhite() ? board.getBlackPieces() : board.getWhitePieces();
+        if (board.pieceAt(pawnSquare) != Piece.PAWN || (Bits.of(pawnSquare) & colorPieces) == 0) {
+            throw new IllegalArgumentException(String.format("Illegal 'en passant' square. There's no %s pawn at %s!", colorLabel(!board.isWhite()), Square.toNotation(pawnSquare)));
+        }
     }
     
     private static void checkCastlingRights(Board board, int castlingRights) {
@@ -305,7 +318,7 @@ public class FEN {
         return sideToMove ? "w" : "b";
     }
 
-    private static int parseCastlingRights(String castlingRights, long whiteRooks, long blackRooks, int whiteKing, int blackKing) {
+    private static int parseCastlingRights(String castlingRights, long whiteRooks, long blackRooks, int whiteKing, int blackKing, boolean isChess960Supported) {
         if (castlingRights.length() > 4) {
             throw new IllegalArgumentException("Invalid castling rights! " + castlingRights);
         }
@@ -383,11 +396,15 @@ public class FEN {
         return rightsString;
     }
 
-    private static int parseEnPassantFile(String enPassantSquare) {
+    private static int parseEnPassantFile(String enPassantSquare, boolean white) {
         if (enPassantSquare.equals("-")) {
             return -1;
         }
-        int square = Square.fromNotation(enPassantSquare);
+        final int square = Square.fromNotation(enPassantSquare);
+        final int expectedRank = white ? 5 : 2;
+        if (Rank.of(square) != expectedRank) {
+            throw new IllegalArgumentException(String.format("Invalid en passant square! Rank should be %s", Integer.toString(expectedRank+1)));
+        }
         return File.of(square);
     }
 

--- a/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
+++ b/src/main/java/com/kelseyde/calvin/utils/notation/FEN.java
@@ -10,46 +10,53 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
+/** 
+ * Converts a Board to and from a <a href="https://www.chessprogramming.org/Forsyth-Edwards_Notation">Forsyth-Edwards Notation</a>
+ */
 public class FEN {
     private FEN() {
         super();
     }
 
+    /**
+     * The standard starting position in Forsyth-Edwards Notation.
+     */
     public static final String STARTPOS = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-    public static Board toBoard(String fen) {
-            if (fen==null) {
-                throw new IllegalArgumentException();
-            }
-            String[] parts = fen.split(" ");
-            String[] files = parts[0].split("/");
+    private static final class PiecesParser {
+        private static final String noPieceCode = "x";
+        private long whitePawns = 0L;
+        private long whiteKnights = 0L;
+        private long whiteBishops = 0L;
+        private long whiteRooks = 0L;
+        private long whiteQueens = 0L;
+        private long whiteKing = 0L;
+        private long blackPawns = 0L;
+        private long blackKnights = 0L;
+        private long blackBishops = 0L;
+        private long blackRooks = 0L;
+        private long blackQueens = 0L;
+        private long blackKing = 0L;
 
-            long whitePawns = 0L;
-            long whiteKnights = 0L;
-            long whiteBishops = 0L;
-            long whiteRooks = 0L;
-            long whiteQueens = 0L;
-            long whiteKing = 0L;
-            long blackPawns = 0L;
-            long blackKnights = 0L;
-            long blackBishops = 0L;
-            long blackRooks = 0L;
-            long blackQueens = 0L;
-            long blackKing = 0L;
-
+        PiecesParser (String[] files) {
             List<List<String>> rankFileHash = Arrays.stream(files)
                     .map(file -> Arrays.stream(file.split(""))
-                            .flatMap(FEN::parseSquare)
+                            .flatMap(this::parseSquare)
                             .toList())
                     .collect(Collectors.toList());
+            if (rankFileHash.size() != 8) {
+                throw new IllegalArgumentException("Illegal FEN: rank count is not 8!");
+            }
             Collections.reverse(rankFileHash);
-
             for (int rankIndex = 0; rankIndex < rankFileHash.size(); rankIndex++) {
-                List<String> rank = rankFileHash.get(rankIndex);
+                final List<String> rank = rankFileHash.get(rankIndex);
+                if (rank.size() != 8) {
+                    throw new IllegalArgumentException("Illegal FEN: file count is not 8!");
+                }
                 for (int fileIndex = 0; fileIndex < rank.size(); fileIndex++) {
-                    int square = Square.of(rankIndex, fileIndex);
-                    String squareValue = rank.get(fileIndex);
-                    long squareBB = Bits.of(square);
+                    final int square = Square.of(rankIndex, fileIndex);
+                    final String squareValue = rank.get(fileIndex);
+                    final long squareBB = Bits.of(square);
                     switch (squareValue) {
                         case "P" -> whitePawns |= squareBB;
                         case "N" -> whiteKnights |= squareBB;
@@ -63,36 +70,84 @@ public class FEN {
                         case "r" -> blackRooks |= squareBB;
                         case "q" -> blackQueens |= squareBB;
                         case "k" -> blackKing |= squareBB;
+                        case noPieceCode -> {
+                            // No piece, do nothing
+                        }
+                        default -> illegalPiece(squareValue);
                     }
                 }
             }
+        }
+        
+        private Stream<String> parseSquare(String square) {
+            if (square.length() != 1) {
+                // A rank was empty
+                throw new IllegalArgumentException("Illegal FEN a rank can't be empty!");
+            }
+            if (Character.isLetter(square.charAt(0))) {
+                if (noPieceCode.equals(square)) {
+                    illegalPiece(square);
+                } else {
+                    return Stream.of(square);
+                }
+            }
+            return IntStream.range(0, Integer.parseInt(square)).mapToObj(i -> noPieceCode);
+        }
 
-            long pawns = whitePawns | blackPawns;
-            long knight = whiteKnights | blackKnights;
-            long bishops = whiteBishops | blackBishops;
-            long rooks = whiteRooks | blackRooks;
-            long queens = whiteQueens | blackQueens;
-            long king = whiteKing | blackKing;
-            long whitePieces = whitePawns | whiteKnights | whiteBishops | whiteRooks | whiteQueens | whiteKing;
-            long blackPieces = blackPawns | blackKnights | blackBishops | blackRooks | blackQueens | blackKing;
+        private void illegalPiece(String piece) {
+            throw new IllegalArgumentException("Illegal FEN: " + piece + " is not a valid piece!");
+        }
 
-            boolean whiteToMove = parseSideToMove(parts[1]);
-            int castlingRights = parseCastlingRights(parts[2], whiteRooks, blackRooks, Bits.next(whiteKing), Bits.next(blackKing));
-            int enPassantFile = parseEnPassantFile(parts[3]);
-            int fiftyMoveCounter = parts.length > 4 ? parseFiftyMoveCounter(parts[4]) : 0;
+        private void fillBoard(Board board) {
+            board.setPawns(whitePawns | blackPawns);
+            board.setKnights(whiteKnights | blackKnights);
+            board.setBishops(whiteBishops | blackBishops);
+            board.setRooks(whiteRooks | blackRooks);
+            board.setQueens(whiteQueens | blackQueens);
+            board.setKings(whiteKing | blackKing);
+            board.setWhitePieces(whitePawns | whiteKnights | whiteBishops | whiteRooks | whiteQueens | whiteKing);
+            board.setBlackPieces(blackPawns | blackKnights | blackBishops | blackRooks | blackQueens | blackKing);
+            board.setPieces(calculatePieceList(board));
+        }
+        
+        private Piece[] calculatePieceList(Board board) {
+            final Piece[] pieceList = new Piece[Square.COUNT];
+            for (int square = 0; square < Square.COUNT; square++) {
+                final long squareMask = Bits.of(square);
+                if ((squareMask & board.getPawns()) != 0)           pieceList[square] = Piece.PAWN;
+                else if ((squareMask & board.getKnights()) != 0)    pieceList[square] = Piece.KNIGHT;
+                else if ((squareMask & board.getBishops()) != 0)    pieceList[square] = Piece.BISHOP;
+                else if ((squareMask & board.getRooks()) != 0)      pieceList[square] = Piece.ROOK;
+                else if ((squareMask & board.getQueens()) != 0)     pieceList[square] = Piece.QUEEN;
+                else if ((squareMask & board.getKings()) != 0)      pieceList[square] = Piece.KING;
+            }
+            return pieceList;
+        }
+    }
+
+    /** 
+     * Converts a Forsyth-Edwards Notation string to a Board
+     * @param fen the Forsyth-Edwards Notation string. Both half move clock and move counter are optional.
+     * <br>If half move clock is not provided, it is set to 0.
+     * <br>Move counter is ignored, due to a limitation of Board class that does not support it when played moves are not provided.
+     * @return the Board
+     * @throws IllegalArgumentException if the FEN string is not valid
+     */
+    public static Board toBoard(String fen) {
+            if (fen==null) {
+                throw new IllegalArgumentException();
+            }
+            final String[] parts = fen.split(" ");
+            final PiecesParser piecesParser = new PiecesParser(parts[0].split("/"));
+
+            final boolean whiteToMove = parseSideToMove(parts[1]);
+            final int castlingRights = parseCastlingRights(parts[2], piecesParser.whiteRooks, piecesParser.blackRooks, Bits.next(piecesParser.whiteKing), Bits.next(piecesParser.blackKing));
+            final int enPassantFile = parseEnPassantFile(parts[3]);
+            final int fiftyMoveCounter = parts.length > 4 ? parseFiftyMoveCounter(parts[4]) : 0;
             // This implementation does not require the full move counter (parts[5]).
 
-            Board board = new Board();
-            board.setBitboards(new long[Piece.COUNT + 2]);
-            board.setPawns(pawns);
-            board.setKnights(knight);
-            board.setBishops(bishops);
-            board.setRooks(rooks);
-            board.setQueens(queens);
-            board.setKings(king);
-            board.setWhitePieces(whitePieces);
-            board.setBlackPieces(blackPieces);
-            board.setPieces(calculatePieceList(board));
+            final Board board = new Board();
+            piecesParser.fillBoard(board);
             board.setWhite(whiteToMove);
             board.getState().setRights(castlingRights);
             board.getState().setEnPassantFile(enPassantFile);
@@ -102,9 +157,13 @@ public class FEN {
             board.getState().setNonPawnKeys(Key.generateNonPawnKeys(board));
 
             return board;
-
     }
 
+    /**
+     * Converts a Board to a Forsyth-Edwards Notation string
+     * @param board the Board
+     * @return the Forsyth-Edwards Notation string
+     */
     public static String toFEN(Board board) {
         try {
             StringBuilder sb = new StringBuilder();
@@ -273,30 +332,6 @@ public class FEN {
 
     private static String toFullMoveCounter(int ply) {
         return Integer.toString(1 + (ply / 2));
-    }
-
-    private static Stream<String> parseSquare(String square) {
-        if (square.length() != 1) {
-            throw new IllegalArgumentException("Illegal square char! " + square);
-        }
-        boolean isLetter = Character.isLetter(square.charAt(0));
-        return isLetter ? Stream.of(square) : IntStream.range(0, Integer.parseInt(square)).mapToObj(i -> "x");
-    }
-
-    public static Piece[] calculatePieceList(Board board) {
-
-        Piece[] pieceList = new Piece[Square.COUNT];
-        for (int square = 0; square < Square.COUNT; square++) {
-            long squareMask = Bits.of(square);
-            if ((squareMask & board.getPawns()) != 0)           pieceList[square] = Piece.PAWN;
-            else if ((squareMask & board.getKnights()) != 0)    pieceList[square] = Piece.KNIGHT;
-            else if ((squareMask & board.getBishops()) != 0)    pieceList[square] = Piece.BISHOP;
-            else if ((squareMask & board.getRooks()) != 0)      pieceList[square] = Piece.ROOK;
-            else if ((squareMask & board.getQueens()) != 0)     pieceList[square] = Piece.QUEEN;
-            else if ((squareMask & board.getKings()) != 0)      pieceList[square] = Piece.KING;
-        }
-        return pieceList;
-
     }
 
     private static int findRook(long rooks, boolean white, boolean kingside) {

--- a/src/test/java/com/kelseyde/calvin/board/BoardBuilderTest.java
+++ b/src/test/java/com/kelseyde/calvin/board/BoardBuilderTest.java
@@ -1,0 +1,17 @@
+package com.kelseyde.calvin.board;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.kelseyde.calvin.utils.notation.FEN;
+
+class BoardBuilderTest {
+
+    @Test
+    void test() {
+        Board board = BoardBuilder.newStandard();
+        assertEquals(FEN.STARTPOS, FEN.toFEN(board));
+    }
+
+}

--- a/src/test/java/com/kelseyde/calvin/movegen/Chess960Test.java
+++ b/src/test/java/com/kelseyde/calvin/movegen/Chess960Test.java
@@ -1,6 +1,8 @@
 package com.kelseyde.calvin.movegen;
 
 import com.kelseyde.calvin.board.*;
+import com.kelseyde.calvin.utils.notation.FEN;
+
 import org.junit.jupiter.api.*;
 
 import java.util.List;
@@ -22,8 +24,7 @@ public class Chess960Test {
     @Test
     public void testRookGoesToKingSquare() {
 
-        Board board = Board.from("qnnbrk1r/ppppp1pp/5p2/3b4/3B4/5P2/PPPPP1PP/QNNBRK1R w KQkq - 2 3");
-        board.setVariant(ChessVariant.CHESS960);
+        Board board = FEN.toBoard("qnnbrk1r/ppppp1pp/5p2/3b4/3B4/5P2/PPPPP1PP/QNNBRK1R w KQkq - 2 3", ChessVariant.CHESS960);
 
         Move target = Move.fromUCI("f1h1", Move.CASTLE_FLAG);
         assertMove(board, target, true);
@@ -38,9 +39,7 @@ public class Chess960Test {
     @Test
     public void testRookGoesToKingSquareBlocked() {
 
-        Board board = Board.from("qnnbrkbr/pppppppp/8/8/8/8/PPPPPPPP/QNNBRKBR w KQkq - 0 1");
-        board.setVariant(ChessVariant.CHESS960);
-
+        Board board = FEN.toBoard("qnnbrkbr/pppppppp/8/8/8/8/PPPPPPPP/QNNBRKBR w KQkq - 0 1", ChessVariant.CHESS960);
         Move target = Move.fromUCI("f1h1", Move.CASTLE_FLAG);
         assertMove(board, target, false);
 
@@ -49,8 +48,7 @@ public class Chess960Test {
     @Test
     public void testQueensideRookOnKingside() {
 
-        Board board = Board.from("qn2rkbr/ppbppppp/1np5/8/8/1NP5/PPBPPPPP/QN2RKBR w KQkq - 2 4");
-        board.setVariant(ChessVariant.CHESS960);
+        Board board = FEN.toBoard("qn2rkbr/ppbppppp/1np5/8/8/1NP5/PPBPPPPP/QN2RKBR w KQkq - 2 4", ChessVariant.CHESS960);
 
         Move target = Move.fromUCI("f1e1", Move.CASTLE_FLAG);
         assertMove(board, target, true);
@@ -64,8 +62,7 @@ public class Chess960Test {
     @Test
     public void testQueensideRookOnKingsideTwo() {
 
-        Board board = Board.from("bbqnr1nQ/1ppppp1p/8/p7/5k2/PP2N3/2PPPP1P/1B2RKNR w KQ - 2 8");
-        board.setVariant(ChessVariant.CHESS960);
+        Board board = FEN.toBoard("bbqnr1nQ/1ppppp1p/8/p7/5k2/PP2N3/2PPPP1P/1B2RKNR w KQ - 2 8", ChessVariant.CHESS960);
 
         Move target = Move.fromUCI("f1e1", Move.CASTLE_FLAG);
         assertMove(board, target, true);
@@ -78,9 +75,7 @@ public class Chess960Test {
 
     @Test
     public void testQueensideRookOnKingsideCastleKingside() {
-
-        Board board = Board.from("bnqbrk1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/BNQBRK1R w KQkq - 2 2");
-        board.setVariant(ChessVariant.CHESS960);
+        Board board = FEN.toBoard("bnqbrk1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/BNQBRK1R w KQkq - 2 2", ChessVariant.CHESS960);
 
         Move target = Move.fromUCI("f1h1", Move.CASTLE_FLAG);
         assertMove(board, target, true);
@@ -94,8 +89,7 @@ public class Chess960Test {
     @Test
     public void testQueensideRookOnKingsideBlocked() {
 
-        Board board = Board.from("nbb1rkrn/pp1ppppp/1qp5/8/8/1QP5/PP1PPPPP/NBB1RKRN w KQkq - 2 3");
-        board.setVariant(ChessVariant.CHESS960);
+        Board board = FEN.toBoard("nbb1rkrn/pp1ppppp/1qp5/8/8/1QP5/PP1PPPPP/NBB1RKRN w KQkq - 2 3", ChessVariant.CHESS960);
 
         Move target = Move.fromUCI("f1e1", Move.CASTLE_FLAG);
         assertMove(board, target, false);
@@ -105,8 +99,7 @@ public class Chess960Test {
     @Test
     public void testKingsideRookOnQueenside() {
 
-        Board board = Board.from("nbbqr2n/ppp2kr1/3ppppp/8/8/3PPPN1/PPPBBQPP/NRKR4 w KQ - 2 8");
-        board.setVariant(ChessVariant.CHESS960);
+        Board board = FEN.toBoard("nbbqr2n/ppp2kr1/3ppppp/8/8/3PPPN1/PPPBBQPP/NRKR4 w KQ - 2 8", ChessVariant.CHESS960);
 
         Move target = Move.fromUCI("c1d1", Move.CASTLE_FLAG);
         assertMove(board, target, true);
@@ -119,8 +112,7 @@ public class Chess960Test {
     @Test
     public void testKingsideRookOnQueensideBlocked() {
 
-        Board board = Board.from("nbbqr1rn/ppp2k2/3ppppp/8/8/3PPPN1/PPPBB1PP/NRKR2Q1 w KQ - 0 7");
-        board.setVariant(ChessVariant.CHESS960);
+        Board board = FEN.toBoard("nbbqr1rn/ppp2k2/3ppppp/8/8/3PPPN1/PPPBB1PP/NRKR2Q1 w KQ - 0 7", ChessVariant.CHESS960);
 
         Move target = Move.fromUCI("c1d1", Move.CASTLE_FLAG);
         assertMove(board, target, false);
@@ -129,8 +121,7 @@ public class Chess960Test {
     @Test
     public void testDontGetConfusedBetweenKingsideQueenside() {
 
-        Board board = Board.from("bqnbrk1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/BQNBRK1R w KQkq - 2 2");
-        board.setVariant(ChessVariant.CHESS960);
+        Board board = FEN.toBoard("bqnbrk1r/pppppppp/5n2/8/8/5N2/PPPPPPPP/BQNBRK1R w KQkq - 2 2", ChessVariant.CHESS960);
         Move kingside = Move.fromUCI("f1h1", Move.CASTLE_FLAG);
         Move queenside = Move.fromUCI("f1e1", Move.CASTLE_FLAG);
         assertMove(board, kingside, true);
@@ -141,8 +132,7 @@ public class Chess960Test {
 	@Test
 	void testKingDoesntMoveCastling() {
 		// Rook is attacked, but the castling is legal
-		final Board board = Board.from("nrk2rnb/pp1ppppp/6b1/q1p5/3P2Q1/1N3N2/1P2PPPP/1RK1BR1B w KQkq - 2 10");
-		board.setVariant(ChessVariant.CHESS960);
+		final Board board = FEN.toBoard("nrk2rnb/pp1ppppp/6b1/q1p5/3P2Q1/1N3N2/1P2PPPP/1RK1BR1B w KQkq - 2 10", ChessVariant.CHESS960);
 		final Move move = Move.fromUCI("c1b1", Move.CASTLE_FLAG);
 		assertMove(board, move, true);
 	}
@@ -150,8 +140,7 @@ public class Chess960Test {
 	@Test
 	void testPinnedRookCastling() {
 		// Test castling where king seems safe ... but is not because it does not move and the rook does not defend it anymore
-		final Board board = Board.from("nrk1brnb/pp1ppppp/8/2p5/3P4/1N1Q1N2/1PP1PPPP/qRK1BR1B w KQkq - 2 10");
-		board.setVariant(ChessVariant.CHESS960);
+		final Board board = FEN.toBoard("nrk1brnb/pp1ppppp/8/2p5/3P4/1N1Q1N2/1PP1PPPP/qRK1BR1B w KQkq - 2 10", ChessVariant.CHESS960);
 		final Move move = Move.fromUCI("c1b1", Move.CASTLE_FLAG);
 		assertMove(board, move, false);
 	}
@@ -183,7 +172,5 @@ public class Chess960Test {
         Assertions.assertFalse(Bits.contains(board.getRooks(true), rookFromSq));
         Assertions.assertTrue(Bits.contains(board.getKing(true), kingToSq));
         Assertions.assertTrue(Bits.contains(board.getRooks(true), rookToSq));
-
     }
-
 }

--- a/src/test/java/com/kelseyde/calvin/movegen/perft/PerftSuiteTest.java
+++ b/src/test/java/com/kelseyde/calvin/movegen/perft/PerftSuiteTest.java
@@ -46,8 +46,7 @@ class PerftSuiteTest {
             	return;
             }
             long expectedTotalMoves = Long.parseLong(parts[depth].split(" ")[1].trim());
-            final Board board = FEN.toBoard(fen);
-            board.setVariant(variant);
+            final Board board = FEN.toBoard(fen, variant);
             final Result result = new Perft().perft(board, depth);
             assertEquals(expectedTotalMoves, result.leafNodesCount(), String.format("Fen: %s, Depth: %s, Expected: %s, Actual: %s", fen, depth, expectedTotalMoves, result.leafNodesCount()));
         });

--- a/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
+++ b/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
@@ -2,6 +2,7 @@ package com.kelseyde.calvin.utils.fen;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.fathzer.chess.utils.test.helper.fen.FENComparator;
 import com.kelseyde.calvin.board.Bits;
 import com.kelseyde.calvin.board.Board;
 import com.kelseyde.calvin.board.BoardState;
@@ -66,6 +67,11 @@ class FENTest {
         assertEquals(0, state.getEnPassantFile());
     }
     
+    private void assertChess960FenEquals(String expected, String actual) {
+        final boolean ok =new FENComparator().withStrictCastling(false).withStrictMoveNumber(false).areEqual(expected, actual);
+        assertTrue(ok, expected + " is not a FEN equivalent of " + actual);
+    }
+    
     @Test
     void testChess960() {
         // Warning, all move counters should be ignored in this test because Board does not support move counter different from the previous move count
@@ -77,10 +83,9 @@ class FENTest {
         assertEquals("h8", Square.toNotation(Castling.getRook(board.getState().getRights(), true, false)));
         assertEquals("e8", Square.toNotation(Castling.getRook(board.getState().getRights(), false, false)));
         
-        //TODO
-//TODO        assertEquals(fen, FEN.toFEN(board));
+        assertChess960FenEquals(fen, FEN.toFEN(board));
         
-        final String fenWithInnerRook = "rn2k1r1/ppp1pp1p/3p2p1/5bn1/P7/2N2B2/1PPPPP2/2BNK1RR w Gkq - 4 1";
+        final String fenWithInnerRook = "rn2k1r1/ppp1pp1p/3p2p1/5bn1/P7/2N2B2/1PPPPP2/2BNK1RR w Gkq - 4 4";
         board = FEN.toBoard(fenWithInnerRook, ChessVariant.CHESS960);
         int rights = board.getState().getRights();
         assertTrue(Castling.kingsideAllowed(rights, true));     
@@ -92,11 +97,11 @@ class FENTest {
         assertEquals(Square.fromNotation("g8"), Castling.getRook(rights, true, false));
         assertEquals(Square.fromNotation("a8"), Castling.getRook(rights, false, false));
 
-//TODO        assertEquals(fenWithInnerRook, FEN.toFEN(board));
+        assertChess960FenEquals(fenWithInnerRook, FEN.toFEN(board));
         
         final String otherFenWithInnerRook = "1r2k1r1/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/RR2K3 w Bkq - 4 1";
         board = FEN.toBoard(otherFenWithInnerRook, ChessVariant.CHESS960);
-//TODO        assertEquals(otherFenWithInnerRook, FEN.toFEN(board));
+        assertChess960FenEquals(otherFenWithInnerRook, FEN.toFEN(board));
         
         // There's no rook at the specified rank
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r2k3/ppp1ppr1/3p2pp/5bn1/P7/2N2B2/1PPPPP2/RR2K3 w Bqg - 4 1", ChessVariant.CHESS960));
@@ -167,5 +172,4 @@ class FENTest {
         // Castling with shredder notation different from a or h files
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1rb1k1r1/1pppqppp/2n2n1b/pP6/4Q3/2NB1P1N/P1PPP1P1/1RB1K1R1 w KQkq - 0 1"));
     }
-
 }

--- a/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
+++ b/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
@@ -1,67 +1,52 @@
 package com.kelseyde.calvin.utils.fen;
 
+import static org.junit.jupiter.api.Assertions.*;
+
 import com.kelseyde.calvin.board.Board;
 import com.kelseyde.calvin.utils.notation.FEN;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.List;
 
-@Disabled
-public class FENTest {
+class FENTest {
 
     @Test
-    public void testStartingPosition() {
+    void testStartingPosition() {
 
         Board fenBoard = FEN.toBoard(FEN.STARTPOS);
         Board newBoard = Board.from(FEN.STARTPOS);
-        Assertions.assertEquals(newBoard.getPawns(true), fenBoard.getPawns(true));
-        Assertions.assertEquals(newBoard.getKnights(true), fenBoard.getKnights(true));
-        Assertions.assertEquals(newBoard.getBishops(true), fenBoard.getBishops(true));
-        Assertions.assertEquals(newBoard.getRooks(true), fenBoard.getRooks(true));
-        Assertions.assertEquals(newBoard.getQueens(true), fenBoard.getQueens(true));
-        Assertions.assertEquals(newBoard.getKing(true), fenBoard.getKing(true));
-        Assertions.assertEquals(newBoard.getPawns(false), fenBoard.getPawns(false));
-        Assertions.assertEquals(newBoard.getKnights(false), fenBoard.getKnights(false));
-        Assertions.assertEquals(newBoard.getBishops(false), fenBoard.getBishops(false));
-        Assertions.assertEquals(newBoard.getRooks(false), fenBoard.getRooks(false));
-        Assertions.assertEquals(newBoard.getQueens(false), fenBoard.getQueens(false));
-        Assertions.assertEquals(newBoard.getKing(false), fenBoard.getKing(false));
+        assertEquals(newBoard.getPawns(true), fenBoard.getPawns(true));
+        assertEquals(newBoard.getKnights(true), fenBoard.getKnights(true));
+        assertEquals(newBoard.getBishops(true), fenBoard.getBishops(true));
+        assertEquals(newBoard.getRooks(true), fenBoard.getRooks(true));
+        assertEquals(newBoard.getQueens(true), fenBoard.getQueens(true));
+        assertEquals(newBoard.getKing(true), fenBoard.getKing(true));
+        assertEquals(newBoard.getPawns(false), fenBoard.getPawns(false));
+        assertEquals(newBoard.getKnights(false), fenBoard.getKnights(false));
+        assertEquals(newBoard.getBishops(false), fenBoard.getBishops(false));
+        assertEquals(newBoard.getRooks(false), fenBoard.getRooks(false));
+        assertEquals(newBoard.getQueens(false), fenBoard.getQueens(false));
+        assertEquals(newBoard.getKing(false), fenBoard.getKing(false));
 
-        Assertions.assertEquals(newBoard.getWhitePieces(), fenBoard.getWhitePieces());
-        Assertions.assertEquals(newBoard.getBlackPieces(), fenBoard.getBlackPieces());
-        Assertions.assertEquals(newBoard.getOccupied(), fenBoard.getOccupied());
+        assertEquals(newBoard.getWhitePieces(), fenBoard.getWhitePieces());
+        assertEquals(newBoard.getBlackPieces(), fenBoard.getBlackPieces());
+        assertEquals(newBoard.getOccupied(), fenBoard.getOccupied());
 
-        Assertions.assertEquals(newBoard.isWhite(), fenBoard.isWhite());
-        Assertions.assertEquals(newBoard.getState(), fenBoard.getState());
-        Assertions.assertEquals(Arrays.asList(newBoard.getStates()), Arrays.asList(fenBoard.getStates()));
-        Assertions.assertEquals(Arrays.asList(newBoard.getMoves()), Arrays.asList(fenBoard.getMoves()));
+        assertEquals(newBoard.isWhite(), fenBoard.isWhite());
+        assertEquals(newBoard.getState(), fenBoard.getState());
+        assertEquals(Arrays.asList(newBoard.getStates()), Arrays.asList(fenBoard.getStates()));
+        assertEquals(Arrays.asList(newBoard.getMoves()), Arrays.asList(fenBoard.getMoves()));
 
     }
-
+    
     @Test
-    public void testAllFens() throws IOException {
-
-        List<String> fens = loadFens();
-        for (String originalFen : fens) {
-            String actualFen = originalFen.split("\"")[0];
-            Board board = FEN.toBoard(actualFen);
-            String newFen = FEN.toFEN(board);
-            Assertions.assertEquals(actualFen, newFen);
-        }
-
-    }
-
-    private List<String> loadFens() throws IOException {
-        String fileName = "src/test/resources/texel/quiet_positions.epd";
-        Path path = Paths.get(fileName);
-        return Files.readAllLines(path);
+    void testWrongFEN() {
+//        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard(null));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard(""));
+        // Missing pieces 
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbn/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"));
+        
     }
 
 }

--- a/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
+++ b/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
@@ -150,10 +150,12 @@ class FENTest {
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbk1bnr/pppp1ppp/4p3/6q1/8/2P5/PPQPPPPP/RNB1KBNR w k - 0 1"));
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbk1bnr/pppp1ppp/4p3/6q1/8/2P5/PPQPPPPP/RNB1KBNR w q - 0 1"));
         
-        // Illegal en passant
-        
-        // Use of Shredder FEN castling rights in standard board
-        
+        // Illegal en passant (no pawn there)
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("r1b1k2r/1pppqppp/2n2n1b/1P6/p3Q3/3B1P1N/P1PPP1P1/RNB1K2R w KQq a6 0 1"));
+        // Illegal en passant (not the right color to play)
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("r1b1k2r/1pppqppp/2n2n1b/pP6/4Q3/3B1P1N/P1PPP1P1/RNB1K2R b KQq a6"));
+        // Illegal en passant (no the right rank)
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("r1b1k2r/1pppqppp/2n2n1b/pP6/4Q3/3B1P1N/P1PPP1P1/RNB1K2R w KQq a5 0 1"));
     }
 
 }

--- a/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
+++ b/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
@@ -3,49 +3,66 @@ package com.kelseyde.calvin.utils.fen;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.kelseyde.calvin.board.Board;
+import com.kelseyde.calvin.board.BoardState;
+import com.kelseyde.calvin.board.Castling;
 import com.kelseyde.calvin.utils.notation.FEN;
 import org.junit.jupiter.api.Test;
-
-import java.util.Arrays;
 
 class FENTest {
 
     @Test
     void testStartingPosition() {
-
         Board fenBoard = FEN.toBoard(FEN.STARTPOS);
-        Board newBoard = Board.from(FEN.STARTPOS);
-        assertEquals(newBoard.getPawns(true), fenBoard.getPawns(true));
-        assertEquals(newBoard.getKnights(true), fenBoard.getKnights(true));
-        assertEquals(newBoard.getBishops(true), fenBoard.getBishops(true));
-        assertEquals(newBoard.getRooks(true), fenBoard.getRooks(true));
-        assertEquals(newBoard.getQueens(true), fenBoard.getQueens(true));
-        assertEquals(newBoard.getKing(true), fenBoard.getKing(true));
-        assertEquals(newBoard.getPawns(false), fenBoard.getPawns(false));
-        assertEquals(newBoard.getKnights(false), fenBoard.getKnights(false));
-        assertEquals(newBoard.getBishops(false), fenBoard.getBishops(false));
-        assertEquals(newBoard.getRooks(false), fenBoard.getRooks(false));
-        assertEquals(newBoard.getQueens(false), fenBoard.getQueens(false));
-        assertEquals(newBoard.getKing(false), fenBoard.getKing(false));
+        assertEquals(0b0000000000000000000000000000000000000000000000001111111100000000L, fenBoard.getPawns(true));
+        assertEquals(0b0000000000000000000000000000000000000000000000000000000001000010L, fenBoard.getKnights(true));
+        assertEquals(0b0000000000000000000000000000000000000000000000000000000000100100L, fenBoard.getBishops(true));
+        assertEquals(0b0000000000000000000000000000000000000000000000000000000010000001L, fenBoard.getRooks(true));
+        assertEquals(0b0000000000000000000000000000000000000000000000000000000000001000L, fenBoard.getQueens(true));
+        assertEquals(0b0000000000000000000000000000000000000000000000000000000000010000L, fenBoard.getKing(true));
+        assertEquals(0b0000000011111111000000000000000000000000000000000000000000000000L, fenBoard.getPawns(false));
+        assertEquals(0b0100001000000000000000000000000000000000000000000000000000000000L, fenBoard.getKnights(false));
+        assertEquals(0b0010010000000000000000000000000000000000000000000000000000000000L, fenBoard.getBishops(false));
+        assertEquals(0b1000000100000000000000000000000000000000000000000000000000000000L, fenBoard.getRooks(false));
+        assertEquals(0b0000100000000000000000000000000000000000000000000000000000000000L, fenBoard.getQueens(false));
+        assertEquals(0b0001000000000000000000000000000000000000000000000000000000000000L, fenBoard.getKing(false));
 
-        assertEquals(newBoard.getWhitePieces(), fenBoard.getWhitePieces());
-        assertEquals(newBoard.getBlackPieces(), fenBoard.getBlackPieces());
-        assertEquals(newBoard.getOccupied(), fenBoard.getOccupied());
+        assertEquals(0b0000000000000000000000000000000000000000000000001111111111111111L, fenBoard.getWhitePieces());
+        assertEquals(0b1111111111111111000000000000000000000000000000000000000000000000L, fenBoard.getBlackPieces());
+        assertEquals(0b1111111111111111000000000000000000000000000000001111111111111111L, fenBoard.getOccupied());
 
-        assertEquals(newBoard.isWhite(), fenBoard.isWhite());
-        assertEquals(newBoard.getState(), fenBoard.getState());
-        assertEquals(Arrays.asList(newBoard.getStates()), Arrays.asList(fenBoard.getStates()));
-        assertEquals(Arrays.asList(newBoard.getMoves()), Arrays.asList(fenBoard.getMoves()));
-
+        assertTrue(fenBoard.isWhite());
+        BoardState state = fenBoard.getState();
+        assertEquals(0, state.halfMoveClock);
+        assertEquals(-1, state.enPassantFile);
+        final int rights = state.rights;
+        assertTrue(Castling.kingsideAllowed(rights, true));
+        assertTrue(Castling.kingsideAllowed(rights, false));
+        assertTrue(Castling.queensideAllowed(rights, true));
+        assertTrue(Castling.queensideAllowed(rights, true));
     }
     
     @Test
     void testWrongFEN() {
-//        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard(null));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard(null));
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard(""));
-        // Missing pieces 
+        
+        // Problems in pieces
+        // Missing a file
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbn/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"));
+        // Missing a rank
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"));
+        // Empty a rank
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp//8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"));
+        // Missing the pieces
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("w KQkq - 0 1"));
+        // Illegal piece code
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnTqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1"));
+        
+        // Problems in color to play
+        // Missing color to play
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR KQkq - 0 1"));
+        // Invalid color
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR x KQkq - 0 1"));
         
     }
 

--- a/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
+++ b/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
@@ -111,6 +111,8 @@ class FENTest {
         // Illegal castling : Both color has castling rights but rooks are not on the same file
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r2k1r1/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/1R2KR2 w Kk - 4 1", ChessVariant.CHESS960));
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r2kr2/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/R3KR2 w Qq - 4 1", ChessVariant.CHESS960));
+        // Two queen side castling defined
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rr2k3/1pppqppp/2nb1n1b/pP6/4Q3/2NBBP1N/P1PPP1P1/RR2K3 w BQbq - 0 1", ChessVariant.CHESS960));
     }
     
     @Test
@@ -156,6 +158,14 @@ class FENTest {
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("r1b1k2r/1pppqppp/2n2n1b/pP6/4Q3/3B1P1N/P1PPP1P1/RNB1K2R b KQq a6"));
         // Illegal en passant (no the right rank)
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("r1b1k2r/1pppqppp/2n2n1b/pP6/4Q3/3B1P1N/P1PPP1P1/RNB1K2R w KQq a5 0 1"));
+        
+        // Two kings of same color
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("r1b1k2r/1pppqppp/2nk1n1b/pP6/4Q3/3B1P1N/P1PPP1P1/RNB1K2R w - - 0 1"));
+        // No king for one color
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("r1b4r/1pppqppp/2n2n1b/pP6/4Q3/3B1P1N/P1PPP1P1/RNB1K2R w - - 0 1"));
+        
+        // Castling with shredder notation different from a or h files
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1rb1k1r1/1pppqppp/2n2n1b/pP6/4Q3/2NB1P1N/P1PPP1P1/1RB1K1R1 w KQkq - 0 1"));
     }
 
 }

--- a/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
+++ b/src/test/java/com/kelseyde/calvin/utils/fen/FENTest.java
@@ -2,9 +2,13 @@ package com.kelseyde.calvin.utils.fen;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import com.kelseyde.calvin.board.Bits;
 import com.kelseyde.calvin.board.Board;
 import com.kelseyde.calvin.board.BoardState;
 import com.kelseyde.calvin.board.Castling;
+import com.kelseyde.calvin.board.ChessVariant;
+import com.kelseyde.calvin.board.Piece;
+import com.kelseyde.calvin.board.Square;
 import com.kelseyde.calvin.utils.notation.FEN;
 import org.junit.jupiter.api.Test;
 
@@ -32,13 +36,81 @@ class FENTest {
 
         assertTrue(fenBoard.isWhite());
         BoardState state = fenBoard.getState();
-        assertEquals(0, state.halfMoveClock);
-        assertEquals(-1, state.enPassantFile);
+        assertEquals(0, state.getHalfMoveClock());
+        assertEquals(-1, state.getEnPassantFile());
         final int rights = state.rights;
         assertTrue(Castling.kingsideAllowed(rights, true));
         assertTrue(Castling.kingsideAllowed(rights, false));
         assertTrue(Castling.queensideAllowed(rights, true));
         assertTrue(Castling.queensideAllowed(rights, true));
+    }
+    
+    @Test
+    void testStandardChess() {
+        final Board board = FEN.toBoard("r1b1k2r/1pppqppp/2n2n1b/pP6/4Q3/3B1P1N/P1PPP1P1/RNB1K2R w KQq a6");
+        final BoardState state = board.getState();
+        // Default half move clock is 0
+        assertEquals(0, state.getHalfMoveClock());
+        // e4 should be a white queen
+        int e4 = Square.fromNotation("e4");
+        assertEquals(Piece.QUEEN, board.pieceAt(e4));
+        assertTrue(Bits.contains(board.getWhitePieces(), e4));
+        assertTrue(Bits.contains(board.getQueens(), e4));
+        // Check castlings
+        int rights = state.getRights();
+        assertTrue(Castling.kingsideAllowed(rights, true));
+        assertFalse(Castling.kingsideAllowed(rights, false));
+        assertTrue(Castling.queensideAllowed(rights, true));
+        assertTrue(Castling.queensideAllowed(rights, true));
+        // Check en passant
+        assertEquals(0, state.getEnPassantFile());
+    }
+    
+    @Test
+    void testChess960() {
+        // Warning, all move counters should be ignored in this test because Board does not support move counter different from the previous move count
+        final var fen = "nbbqrknr/pppppppp/8/8/8/8/PPPPPPPP/NBBQRKNR w KQkq - 0 1";
+        var board = FEN.toBoard(fen, ChessVariant.CHESS960);
+        // Check from position of rooks in castling rights
+        assertEquals("h1", Square.toNotation(Castling.getRook(board.getState().getRights(), true, true)));
+        assertEquals("e1", Square.toNotation(Castling.getRook(board.getState().getRights(), false, true)));
+        assertEquals("h8", Square.toNotation(Castling.getRook(board.getState().getRights(), true, false)));
+        assertEquals("e8", Square.toNotation(Castling.getRook(board.getState().getRights(), false, false)));
+        
+        //TODO
+//TODO        assertEquals(fen, FEN.toFEN(board));
+        
+        final String fenWithInnerRook = "rn2k1r1/ppp1pp1p/3p2p1/5bn1/P7/2N2B2/1PPPPP2/2BNK1RR w Gkq - 4 1";
+        board = FEN.toBoard(fenWithInnerRook, ChessVariant.CHESS960);
+        int rights = board.getState().getRights();
+        assertTrue(Castling.kingsideAllowed(rights, true));     
+        assertFalse(Castling.queensideAllowed(rights, true));     
+        assertTrue(Castling.kingsideAllowed(rights, false));     
+        assertTrue(Castling.queensideAllowed(rights, false));
+        
+        assertEquals(Square.fromNotation("g1"), Castling.getRook(rights, true, true));
+        assertEquals(Square.fromNotation("g8"), Castling.getRook(rights, true, false));
+        assertEquals(Square.fromNotation("a8"), Castling.getRook(rights, false, false));
+
+//TODO        assertEquals(fenWithInnerRook, FEN.toFEN(board));
+        
+        final String otherFenWithInnerRook = "1r2k1r1/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/RR2K3 w Bkq - 4 1";
+        board = FEN.toBoard(otherFenWithInnerRook, ChessVariant.CHESS960);
+//TODO        assertEquals(otherFenWithInnerRook, FEN.toFEN(board));
+        
+        // There's no rook at the specified rank
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r2k3/ppp1ppr1/3p2pp/5bn1/P7/2N2B2/1PPPPP2/RR2K3 w Bqg - 4 1", ChessVariant.CHESS960));
+        // Illegal castling : King is not at its staring rank
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r4r1/pppkpp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/RR2K3 w Bqg - 4 1", ChessVariant.CHESS960));
+        // Illegal castling : King is not at its starting file (that can't be 'a' or 'h')
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r4rk/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/1R2K1R1 w KQq - 4 1", ChessVariant.CHESS960));
+        // Illegal castling : King is not between its rooks start position
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r3rk1/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/1R2KR2 w k - 4 1", ChessVariant.CHESS960));
+        // Illegal castling : Both color has castling rights but kings are not on the same file
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r2kr2/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/1R1K1R2 w KQkq - 4 1", ChessVariant.CHESS960));
+        // Illegal castling : Both color has castling rights but rooks are not on the same file
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r2k1r1/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/1R2KR2 w Kk - 4 1", ChessVariant.CHESS960));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1r2kr2/ppp1pp2/3p2pp/5bn1/P7/2N2B2/1PPPPP2/R3KR2 w Qq - 4 1", ChessVariant.CHESS960));
     }
     
     @Test
@@ -63,6 +135,24 @@ class FENTest {
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR KQkq - 0 1"));
         // Invalid color
         assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR x KQkq - 0 1"));
+        
+        // Illegal castling rights
+        // Missing rook
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp/8/8/P7/R7/1PPPPPPP/1NBQKBNR w QK - 0 1"));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbnr/pppppppp/8/8/8/7R/PPPPPPPP/RNBQKBN1 w K - 0 1"));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbqkbn1/pppppppp/7r/8/8/8/PPPPPPPP/RNBQKBNR w k - 0 1"));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1nbqkbnr/pppppppp/r7/8/8/8/PPPPPPPP/RNBQKBNR w q - 0 1"));
+        // Wrong rook color
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("1nbqkbnr/1ppppppp/8/p7/P7/2R5/1PPPPPPP/rNBQKBNR w QK - 0 1"));
+        // King is not on its starting position
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnb1kbnr/pppp1ppp/4p3/6q1/8/2P5/PPQPPPPP/RNBK1BNR w K - 0 1"));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnb1kbnr/pppp1ppp/4p3/6q1/8/2P5/PPQPPPPP/RNBK1BNR w Q - 0 1"));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbk1bnr/pppp1ppp/4p3/6q1/8/2P5/PPQPPPPP/RNB1KBNR w k - 0 1"));
+        assertThrows(IllegalArgumentException.class, () -> FEN.toBoard("rnbk1bnr/pppp1ppp/4p3/6q1/8/2P5/PPQPPPPP/RNB1KBNR w q - 0 1"));
+        
+        // Illegal en passant
+        
+        // Use of Shredder FEN castling rights in standard board
         
     }
 


### PR DESCRIPTION
Hello Dan,

I started working on the `FEN` class ... and other things.  
For now, it's still a preview (it lacks bug fixes in FEN.toFEN). I'm creating this PR to keep you informed of the progress of my work and give you the opportunity to comment on it.

Here are the first changes in the `FEN` class:
- Added tests of the `toBoard` method, to check the behavior when faced with incorrect fen.
- Added the `toBoard(String, ChessVariant)` method.
- Refactored the `toBoard` method to use the `BoardBuilder` class (See below).
- Fixes so that `toBoard` throws an `IllegalArgumentException` when the passed FEN is incorrect.
- Added javadoc

In the `Colour` class
- Added the `label(boolean)` method.

Adding the `BoardBuilder` class
- The idea is that it was quite difficult to build a consistent `Board` instance, outside of the methods that parse a FEN.
For example, I struggled for a while to find a bug; I had forgotten to call one of the `setKey`, `setPawnKey` or `setNonPawnKeys` methods of `BoardState`.
It was also very easy to build an inconsistent board, with, for example, an array of pieces that does not match the bitmaps.
The `BoardBuilder` allows to build a `Board` from a very simple interface: Add pieces, castling rights, en passant file, etc.
Its `build` method ensures that there is no logical inconsistencies (castling rights when there are no rooks on the board, en passant without a pawn, etc...), and builds a `Board` without risk of having inconsistencies
due to a bad use of `Board` methods.

This class should also allow to reduce the visibility of the `Board` class setters. These allow a clumsy user to very easily put a board in an inconsistent state (for example, by changing a single bitmap).
If you agree, I would can take care of this in another PR.

Regards,

Jean-Marc